### PR TITLE
feat: tags support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You need the following permissions to run this module.
 | <a name="input_cos_key_ring_name"></a> [cos\_key\_ring\_name](#input\_cos\_key\_ring\_name) | A String containing the desired Key Ring Names as the key of the map for the key protect instance, this Key Protect Key is used to encrypt the data in the COS Bucket | `string` | `"cos-key-ring"` | no |
 | <a name="input_cos_location"></a> [cos\_location](#input\_cos\_location) | Location of the cloud object storage instance | `string` | `"global"` | no |
 | <a name="input_cos_plan"></a> [cos\_plan](#input\_cos\_plan) | Plan to be used for creating cloud object storage instance | `string` | `"standard"` | no |
+| <a name="input_cos_tags"></a> [cos\_tags](#input\_cos\_tags) | Optional list of tags to be added to cloud object storage instance. | `list(string)` | `[]` | no |
 | <a name="input_create_cos_instance"></a> [create\_cos\_instance](#input\_create\_cos\_instance) | Set as true to create a new Cloud Object Storage instance | `bool` | `true` | no |
 | <a name="input_create_key_protect_instance"></a> [create\_key\_protect\_instance](#input\_create\_key\_protect\_instance) | Set as true to create a new Key Protect instance, this instance will store the Key used to encrypt the data in the COS Bucket | `bool` | `true` | no |
 | <a name="input_create_key_protect_key"></a> [create\_key\_protect\_key](#input\_create\_key\_protect\_key) | Set as true to create a new Key Protect Key, this Key Protect Key is used to encrypt the COS Bucket | `bool` | `true` | no |
@@ -116,6 +117,7 @@ You need the following permissions to run this module.
 | <a name="input_expire_days"></a> [expire\_days](#input\_expire\_days) | Specifies the number of days when the expire rule action takes effect. | `number` | `365` | no |
 | <a name="input_key_protect_instance_name"></a> [key\_protect\_instance\_name](#input\_key\_protect\_instance\_name) | Name to set as the instance name if creating a Key Protect instance, otherwise name of an existing Key Protect instance to use, this instance will store the Key used to encrypt the data in the COS Bucket | `string` | `null` | no |
 | <a name="input_key_protect_key_crn"></a> [key\_protect\_key\_crn](#input\_key\_protect\_key\_crn) | CRN of the Key Protect Key to use if not creating a Key in this module, this Key Protect Key is used to encrypt the data in the COS Bucket | `string` | `null` | no |
+| <a name="input_key_protect_tags"></a> [key\_protect\_tags](#input\_key\_protect\_tags) | Optional list of tags to be added to Key Protect instance. | `list(string)` | `[]` | no |
 | <a name="input_object_versioning_enabled"></a> [object\_versioning\_enabled](#input\_object\_versioning\_enabled) | Enable object versioning to keep multiple versions of an object in a bucket. Cannot be used with retention rule. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | Name of the Region to deploy in to | `string` | `"us-south"` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where the environment will be created | `string` | n/a | yes |

--- a/examples/bucket-without-tracking-monitoring/main.tf
+++ b/examples/bucket-without-tracking-monitoring/main.tf
@@ -6,9 +6,9 @@ module "resource_group" {
 }
 
 # Create COS bucket with:
-# - Retention
 # - Encryption
 # Create COS bucket without:
+# - Retention
 # - Monitoring
 # - Activity Tracking
 
@@ -18,4 +18,6 @@ module "cos" {
   resource_group_id  = module.resource_group.resource_group_id
   region             = var.region
   encryption_enabled = true
+  cos_tags           = var.resource_tags
+  retention_enabled  = false
 }

--- a/examples/bucket-without-tracking-monitoring/variables.tf
+++ b/examples/bucket-without-tracking-monitoring/variables.tf
@@ -28,9 +28,8 @@ variable "resource_group" {
   default     = null
 }
 
-# tflint-ignore: terraform_unused_declarations
 variable "resource_tags" {
   type        = list(string)
   description = "Optional list of tags to be added to created resources"
-  default     = []
+  default     = ["test-wo-mon"]
 }

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "kp_all_inclusive" {
   key_protect_instance_name   = var.key_protect_instance_name == null ? "${var.environment_name}-kp" : var.key_protect_instance_name
   create_key_protect_instance = var.create_key_protect_instance
   key_map                     = local.key_map
+  resource_tags               = var.key_protect_tags
 }
 
 # Resource to create COS instance if create_cos_instance is true
@@ -59,6 +60,7 @@ resource "ibm_resource_instance" "cos_instance" {
   service           = "cloud-object-storage"
   plan              = var.cos_plan
   location          = var.cos_location
+  tags              = var.cos_tags
 }
 
 locals {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -17,7 +17,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 159
+        "line": 171
       }
     },
     "archive_type": {
@@ -27,7 +27,7 @@
       "default": "Glacier",
       "pos": {
         "filename": "variables.tf",
-        "line": 165
+        "line": 177
       }
     },
     "bucket_infix": {
@@ -61,7 +61,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 141
+        "line": 153
       }
     },
     "cos_key_ring_name": {
@@ -71,7 +71,7 @@
       "default": "cos-key-ring",
       "pos": {
         "filename": "variables.tf",
-        "line": 135
+        "line": 147
       }
     },
     "cos_location": {
@@ -106,6 +106,26 @@
         "line": 53
       }
     },
+    "cos_tags": {
+      "name": "cos_tags",
+      "type": "list(string)",
+      "description": "Optional list of tags to be added to cloud object storage instance.",
+      "default": [],
+      "source": [
+        "ibm_resource_instance.cos_instance.tags"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 69
+      },
+      "min_length": 1,
+      "max_length": 128,
+      "matches": "^[A-Za-z0-9:_ .-]+$",
+      "computed": true,
+      "elem": {
+        "type": "TypeString"
+      }
+    },
     "create_cos_instance": {
       "name": "create_cos_instance",
       "type": "bool",
@@ -131,7 +151,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 123
+        "line": 129
       }
     },
     "create_key_protect_key": {
@@ -141,7 +161,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 147
+        "line": 159
       }
     },
     "encryption_enabled": {
@@ -156,7 +176,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 117
+        "line": 123
       }
     },
     "environment_name": {
@@ -183,7 +203,7 @@
       "default": 365,
       "pos": {
         "filename": "variables.tf",
-        "line": 175
+        "line": 187
       }
     },
     "key_protect_instance_name": {
@@ -197,7 +217,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 129
+        "line": 135
       }
     },
     "key_protect_key_crn": {
@@ -206,7 +226,27 @@
       "description": "CRN of the Key Protect Key to use if not creating a Key in this module, this Key Protect Key is used to encrypt the data in the COS Bucket",
       "pos": {
         "filename": "variables.tf",
-        "line": 153
+        "line": 165
+      }
+    },
+    "key_protect_tags": {
+      "name": "key_protect_tags",
+      "type": "list(string)",
+      "description": "Optional list of tags to be added to Key Protect instance.",
+      "default": [],
+      "source": [
+        "module.kp_all_inclusive.module.key_protect.ibm_resource_instance.key_protect_instance.tags"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 141
+      },
+      "min_length": 1,
+      "max_length": 128,
+      "matches": "^[A-Za-z0-9:_ .-]+$",
+      "computed": true,
+      "elem": {
+        "type": "TypeString"
       }
     },
     "object_versioning_enabled": {
@@ -216,7 +256,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 111
+        "line": 117
       }
     },
     "region": {
@@ -273,7 +313,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 75
+        "line": 81
       }
     },
     "retention_enabled": {
@@ -283,7 +323,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 69
+        "line": 75
       }
     },
     "retention_maximum": {
@@ -293,7 +333,7 @@
       "default": 350,
       "pos": {
         "filename": "variables.tf",
-        "line": 85
+        "line": 91
       }
     },
     "retention_minimum": {
@@ -303,7 +343,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 95
+        "line": 101
       }
     },
     "retention_permanent": {
@@ -313,7 +353,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 105
+        "line": 111
       }
     },
     "sysdig_crn": {
@@ -373,17 +413,12 @@
     },
     "resource_group_id": {
       "name": "resource_group_id",
-      "description": "The resource group ID where the environment will be created",
+      "description": "Resource Group ID",
       "value": "var.resource_group_id",
       "pos": {
         "filename": "outputs.tf",
         "line": 4
-      },
-      "type": "string",
-      "cloud_data_type": "resource_group",
-      "cloud_data_range": [
-        "resolved_to:id"
-      ]
+      }
     },
     "s3_endpoint_private": {
       "name": "s3_endpoint_private",
@@ -436,7 +471,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 94
+        "line": 96
       }
     },
     "ibm_cos_bucket.cos_bucket1": {
@@ -453,7 +488,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 168
+        "line": 170
       }
     },
     "ibm_iam_authorization_policy.policy": {
@@ -465,7 +500,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 80
+        "line": 82
       }
     },
     "ibm_resource_instance.cos_instance": {
@@ -477,14 +512,15 @@
         "location": "cos_location",
         "name": "environment_name",
         "plan": "cos_plan",
-        "resource_group_id": "resource_group_id"
+        "resource_group_id": "resource_group_id",
+        "tags": "cos_tags"
       },
       "provider": {
         "name": "ibm"
       },
       "pos": {
         "filename": "main.tf",
-        "line": 55
+        "line": 56
       }
     }
   },
@@ -504,7 +540,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 71
+        "line": 73
       }
     }
   },
@@ -518,7 +554,8 @@
         "key_protect_instance_name": "key_protect_instance_name",
         "prefix": "environment_name",
         "region": "region",
-        "resource_group_id": "resource_group_id"
+        "resource_group_id": "resource_group_id",
+        "resource_tags": "key_protect_tags"
       },
       "managed_resources": {},
       "data_resources": {

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "cos_location" {
   default     = "global"
 }
 
+variable "cos_tags" {
+  description = "Optional list of tags to be added to cloud object storage instance."
+  type        = list(string)
+  default     = []
+}
+
 variable "retention_enabled" {
   description = "Retention enabled for COS bucket"
   type        = bool
@@ -130,6 +136,12 @@ variable "key_protect_instance_name" {
   description = "Name to set as the instance name if creating a Key Protect instance, otherwise name of an existing Key Protect instance to use, this instance will store the Key used to encrypt the data in the COS Bucket"
   type        = string
   default     = null
+}
+
+variable "key_protect_tags" {
+  description = "Optional list of tags to be added to Key Protect instance."
+  type        = list(string)
+  default     = []
 }
 
 variable "cos_key_ring_name" {


### PR DESCRIPTION
Add tags support for cloud object storage and key protect instances

### Description

Add tags support for the cloud object storage and key protect instances.
Add example code on how to set the cloud object storage tags.
Remove 90 day retention from example. Exposing a first example that potentially retains the objects for 90 days seems counter intuitive. Experiment first and enable it later?

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [x] If relevant, a test for the change has been added or updated as part of this PR.
- [x] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
