### PR TITLE
fix: make bucket creation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ You need the following permissions to run this module.
 | <a name="input_cos_location"></a> [cos\_location](#input\_cos\_location) | Location of the cloud object storage instance | `string` | `"global"` | no |
 | <a name="input_cos_plan"></a> [cos\_plan](#input\_cos\_plan) | Plan to be used for creating cloud object storage instance | `string` | `"standard"` | no |
 | <a name="input_cos_tags"></a> [cos\_tags](#input\_cos\_tags) | Optional list of tags to be added to cloud object storage instance. | `list(string)` | `[]` | no |
+| <a name="input_create_cos_bucket"></a> [create\_cos\_bucket](#input\_create\_cos\_bucket) | Set as true to create a new Cloud Object Storage bucket | `bool` | `true` | no |
 | <a name="input_create_cos_instance"></a> [create\_cos\_instance](#input\_create\_cos\_instance) | Set as true to create a new Cloud Object Storage instance | `bool` | `true` | no |
 | <a name="input_create_key_protect_instance"></a> [create\_key\_protect\_instance](#input\_create\_key\_protect\_instance) | Set as true to create a new Key Protect instance, this instance will store the Key used to encrypt the data in the COS Bucket | `bool` | `true` | no |
 | <a name="input_create_key_protect_key"></a> [create\_key\_protect\_key](#input\_create\_key\_protect\_key) | Set as true to create a new Key Protect Key, this Key Protect Key is used to encrypt the COS Bucket | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "ibm_iam_authorization_policy" "policy" {
 # - Activity Tracking
 # - Versioning
 resource "ibm_cos_bucket" "cos_bucket" {
-  count                = var.encryption_enabled ? 1 : 0
+  count                = (var.encryption_enabled && var.create_cos_bucket) ? 1 : 0
   depends_on           = [ibm_iam_authorization_policy.policy]
   bucket_name          = "${var.environment_name}${local.infix}-bucket-${var.region}"
   resource_instance_id = local.cos_instance_id
@@ -169,7 +169,7 @@ resource "ibm_cos_bucket" "cos_bucket" {
 # - Encryption
 
 resource "ibm_cos_bucket" "cos_bucket1" {
-  count                = var.encryption_enabled ? 0 : 1
+  count                = (!var.encryption_enabled && var.create_cos_bucket) ? 1 : 0
   bucket_name          = "${var.environment_name}${local.infix}-bucket-${var.region}"
   resource_instance_id = local.cos_instance_id
   region_location      = var.region

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -17,7 +17,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 171
+        "line": 177
       }
     },
     "archive_type": {
@@ -27,7 +27,7 @@
       "default": "Glacier",
       "pos": {
         "filename": "variables.tf",
-        "line": 177
+        "line": 183
       }
     },
     "bucket_infix": {
@@ -49,7 +49,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 46
+        "line": 52
       }
     },
     "cos_key_name": {
@@ -61,7 +61,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 153
+        "line": 159
       }
     },
     "cos_key_ring_name": {
@@ -71,7 +71,7 @@
       "default": "cos-key-ring",
       "pos": {
         "filename": "variables.tf",
-        "line": 147
+        "line": 153
       }
     },
     "cos_location": {
@@ -86,7 +86,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 63
+        "line": 69
       },
       "cloud_data_type": "region",
       "immutable": true,
@@ -103,7 +103,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 53
+        "line": 59
       }
     },
     "cos_tags": {
@@ -116,7 +116,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 69
+        "line": 75
       },
       "min_length": 1,
       "max_length": 128,
@@ -124,6 +124,16 @@
       "computed": true,
       "elem": {
         "type": "TypeString"
+      }
+    },
+    "create_cos_bucket": {
+      "name": "create_cos_bucket",
+      "type": "bool",
+      "description": "Set as true to create a new Cloud Object Storage bucket",
+      "default": true,
+      "pos": {
+        "filename": "variables.tf",
+        "line": 46
       }
     },
     "create_cos_instance": {
@@ -151,7 +161,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 129
+        "line": 135
       }
     },
     "create_key_protect_key": {
@@ -161,7 +171,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 159
+        "line": 165
       }
     },
     "encryption_enabled": {
@@ -176,7 +186,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 123
+        "line": 129
       }
     },
     "environment_name": {
@@ -203,7 +213,7 @@
       "default": 365,
       "pos": {
         "filename": "variables.tf",
-        "line": 187
+        "line": 193
       }
     },
     "key_protect_instance_name": {
@@ -217,7 +227,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 135
+        "line": 141
       }
     },
     "key_protect_key_crn": {
@@ -226,7 +236,7 @@
       "description": "CRN of the Key Protect Key to use if not creating a Key in this module, this Key Protect Key is used to encrypt the data in the COS Bucket",
       "pos": {
         "filename": "variables.tf",
-        "line": 165
+        "line": 171
       }
     },
     "key_protect_tags": {
@@ -239,7 +249,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 141
+        "line": 147
       },
       "min_length": 1,
       "max_length": 128,
@@ -256,7 +266,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 117
+        "line": 123
       }
     },
     "region": {
@@ -313,7 +323,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 81
+        "line": 87
       }
     },
     "retention_enabled": {
@@ -323,7 +333,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 75
+        "line": 81
       }
     },
     "retention_maximum": {
@@ -333,7 +343,7 @@
       "default": 350,
       "pos": {
         "filename": "variables.tf",
-        "line": 91
+        "line": 97
       }
     },
     "retention_minimum": {
@@ -343,7 +353,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 101
+        "line": 107
       }
     },
     "retention_permanent": {
@@ -353,7 +363,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 111
+        "line": 117
       }
     },
     "sysdig_crn": {

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,12 @@ variable "create_cos_instance" {
   default     = true
 }
 
+variable "create_cos_bucket" {
+  description = "Set as true to create a new Cloud Object Storage bucket"
+  type        = bool
+  default     = true
+}
+
 variable "cos_instance_name" {
   description = "Name of the cos instance where the bucket should be created"
   type        = string


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-cos/issues/70

The creation of buckets should be optional. This will now be possible but creation is on by default.

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
