### PR TITLE
fix: create authorization policy only if creating key protect instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "ibm_resource_instance" "cos_instance" {
 locals {
   cos_instance_id      = var.create_cos_instance == true ? tolist(ibm_resource_instance.cos_instance[*].id)[0] : tolist(data.ibm_resource_instance.cos_instance[*].id)[0]
   cos_instance_guid    = var.create_cos_instance == true ? tolist(ibm_resource_instance.cos_instance[*].guid)[0] : tolist(data.ibm_resource_instance.cos_instance[*].guid)[0]
-  create_access_policy = var.encryption_enabled
+  create_access_policy = var.encryption_enabled && var.create_key_protect_instance
 }
 
 # Data source to retrieve COS instance guid if using an existing COS instance


### PR DESCRIPTION
### Description

Fix an issue where the auth policy is created even when the module is configured to not create the key protect instance.

Spotted as part of updating internal module references. The original internal version of the module had the line that is committed in this PR.

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
