### PR TITLE
fix: allow COS instance name to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You need the following permissions to run this module.
 | <a name="input_archive_days"></a> [archive\_days](#input\_archive\_days) | Specifies the number of days when the archive rule action takes effect. | `number` | `90` | no |
 | <a name="input_archive_type"></a> [archive\_type](#input\_archive\_type) | Specifies the storage class or archive type to which you want the object to transition. | `string` | `"Glacier"` | no |
 | <a name="input_bucket_infix"></a> [bucket\_infix](#input\_bucket\_infix) | Custom infix for use in cos bucket name (Optional) | `string` | `null` | no |
-| <a name="input_cos_instance_name"></a> [cos\_instance\_name](#input\_cos\_instance\_name) | Name of the cos instance where the bucket should be created | `string` | `null` | no |
+| <a name="input_cos_instance_name"></a> [cos\_instance\_name](#input\_cos\_instance\_name) | Name of the COS instance to create when create\_cos\_instance is true, the name of COS instance to create buckets in | `string` | `null` | no |
 | <a name="input_cos_key_name"></a> [cos\_key\_name](#input\_cos\_key\_name) | List of strings containing the list of desired Key Protect Key names as the values for each Key Ring, this Key Protect Key is used to encrypt the data in the COS Bucket | `list(string)` | <pre>[<br>  "cos-key"<br>]</pre> | no |
 | <a name="input_cos_key_ring_name"></a> [cos\_key\_ring\_name](#input\_cos\_key\_ring\_name) | A String containing the desired Key Ring Names as the key of the map for the key protect instance, this Key Protect Key is used to encrypt the data in the COS Bucket | `string` | `"cos-key-ring"` | no |
 | <a name="input_cos_location"></a> [cos\_location](#input\_cos\_location) | Location of the cloud object storage instance | `string` | `"global"` | no |

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
   object_versioning_enabled = var.object_versioning_enabled ? [1] : []
   infix                     = var.bucket_infix == null ? "" : "-${var.bucket_infix}"
 
-  #ensure if create_cos_instance = false, then cos_instance_name is provided
+  # ensure if create_cos_instance = false, then cos_instance_name is provided
   cos_validate_condition = (!var.create_cos_instance && var.cos_instance_name == null)
   cos_validate_msg       = "If create_cos_instance is false, then provide the cos_instance_name to create buckets"
   # tflint-ignore: terraform_unused_declarations
@@ -55,7 +55,7 @@ module "kp_all_inclusive" {
 # Resource to create COS instance if create_cos_instance is true
 resource "ibm_resource_instance" "cos_instance" {
   count             = var.create_cos_instance ? 1 : 0
-  name              = "${var.environment_name}-cos"
+  name              = var.cos_instance_name != null ? var.cos_instance_name : "${var.environment_name}-cos"
   resource_group_id = var.resource_group_id
   service           = "cloud-object-storage"
   plan              = var.cos_plan

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -42,10 +42,11 @@
     "cos_instance_name": {
       "name": "cos_instance_name",
       "type": "string",
-      "description": "Name of the cos instance where the bucket should be created",
+      "description": "Name of the COS instance to create when create_cos_instance is true, the name of COS instance to create buckets in",
       "required": true,
       "source": [
-        "data.ibm_resource_instance.cos_instance.name"
+        "data.ibm_resource_instance.cos_instance.name",
+        "ibm_resource_instance.cos_instance.name"
       ],
       "pos": {
         "filename": "variables.tf",
@@ -197,7 +198,6 @@
       "source": [
         "ibm_cos_bucket.cos_bucket.bucket_name",
         "ibm_cos_bucket.cos_bucket1.bucket_name",
-        "ibm_resource_instance.cos_instance.name",
         "module.kp_all_inclusive"
       ],
       "pos": {
@@ -525,7 +525,7 @@
       "attributes": {
         "count": "create_cos_instance",
         "location": "cos_location",
-        "name": "environment_name",
+        "name": "cos_instance_name",
         "plan": "cos_plan",
         "resource_group_id": "resource_group_id",
         "tags": "cos_tags"

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "create_cos_bucket" {
 }
 
 variable "cos_instance_name" {
-  description = "Name of the cos instance where the bucket should be created"
+  description = "Name of the COS instance to create when create_cos_instance is true, the name of COS instance to create buckets in"
   type        = string
   default     = null
 }


### PR DESCRIPTION
### Description

Use cos_instance_name, if provided, when creating the Cloud Object Storage instance

Address issue: #82

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [x] If relevant, documentation for the change has been added or updated as part of this PR.

### Mention in release notes

Behaviour change, when specifying both `create_cos_instance`=true AND `cos_instance_name` the old behaviour was to ignore the cos_instance_name. The new behaviour is to change the name of the COS instance, which may attempt to delete and recreate the COS instance. 

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
