### PR TITLE
feat: remove support for creating key protect resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,15 @@ provider "ibm" {
 # - COS bucket with retention, encryption, monitoring and activity tracking
 module "cos_module" {
   # Replace "main" with a GIT release version to lock into a specific release
-  source            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-cos?ref=main"
-  resource_group_id         = "xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX"
-  region                    = "us-south"
-  cos_instance_name         = "my-cos-instance"
-  bucket_name               = "my-cos-bucket"
-  key_protect_instance_name = "my-key-protect-instance"
-  cos_key_ring_name         = "cos-key-ring"
-  cos_key_name              = "cos-key"
-  sysdig_crn                = "crn:v1:bluemix:public:sysdig-monitor:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
-  activity_tracker_crn      = "crn:v1:bluemix:public:logdnaat:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
+  source                             = "git::https://github.com/terraform-ibm-modules/terraform-ibm-cos?ref=main"
+  resource_group_id                  = "xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX"
+  region                             = "us-south"
+  cos_instance_name                  = "my-cos-instance"
+  bucket_name                        = "my-cos-bucket"
+  existing_key_protect_instance_guid = "xxxxxxxx-XXXX-XXXX-XXXX-xxxxxxxx"
+  key_protect_key_crn                = "crn:v1:bluemix:public:kms:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxxxxx-XXXX-XXXX-XXXX-xxxxxx:key:xxxxxx-XXXX-XXXX-XXXX-xxxxxx"
+  sysdig_crn                         = "crn:v1:bluemix:public:sysdig-monitor:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
+  activity_tracker_crn               = "crn:v1:bluemix:public:logdnaat:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
 }
 
 # Creates additional bucket in instance created above:
@@ -50,11 +49,8 @@ module "additional_cos_bucket" {
   region                             = "us-south"
   sysdig_crn                         = "crn:v1:bluemix:public:sysdig-monitor:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
   activity_tracker_crn               = "crn:v1:bluemix:public:logdnaat:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
-  create_cos_instance                = false
-  create_key_protect_key             = false
-  create_key_protect_instance        = false
   existing_cos_instance_id           = module.cos_module.cos_instance_id
-  key_protect_key_crn                = module.cos_module.key_protect_key_crn
+  key_protect_key_crn                = "crn:v1:bluemix:public:kms:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxxxxx-XXXX-XXXX-XXXX-xxxxxx:key:xxxxxx-XXXX-XXXX-XXXX-xxxxxx"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![latest release](https://img.shields.io/github/v/release/terraform-ibm-modules/terraform-ibm-cos?logo=GitHub&sort=semver)](https://github.com/terraform-ibm-modules/terraform-ibm-cos/releases/latest)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
-This module can be used to provision and configure a [Cloud Object Storage](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-getting-started-cloud-object-storage) instance and bucket. It can also be used to just provision buckets.
+This module can be used to provision and configure a [Cloud Object Storage](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-getting-started-cloud-object-storage) instance and/or bucket.
 
 You can configure the following aspects of your instances:
 1. [Bucket encryption](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-tutorial-kp-encrypt-bucket) - based on Key Protect keys
@@ -18,32 +18,13 @@ You can configure the following aspects of your instances:
 
 
 ## Usage
-There is currently an [enhancement request](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4256) open with the IBM terraform provider to support enabling metrics for Key Protect. Until then, this module uses the restapi provider to enable metrics since it support provisioning and configuring Key Protect for COS encryption.
-
 ```hcl
 provider "ibm" {
   ibmcloud_api_key = "XXXXXXXXXX" # pragma: allowlist secret
   region           = "us-south"
 }
 
-# Retrieve IAM access token (required for restapi provider)
-data "ibm_iam_auth_token" "token_data" {
-}
-
-provider "restapi" {
-  uri                   = "https:"
-  write_returns_object  = false
-  create_returns_object = false
-  debug                 = false
-  headers = {
-    Authorization    = data.ibm_iam_auth_token.token_data.iam_access_token
-    Bluemix-Instance = module.cos_module.key_protect_instance_guid
-    Content-Type     = "application/vnd.ibm.kms.policy+json"
-  }
-}
-
 # Creates:
-# - Key Protect + Key Ring + Key
 # - COS instance
 # - COS bucket with retention, encryption, monitoring and activity tracking
 module "cos_module" {
@@ -118,13 +99,10 @@ You need the following permissions to run this module.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
-| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >= 1.18.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_kp_all_inclusive"></a> [kp\_all\_inclusive](#module\_kp\_all\_inclusive) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git | v3.0.2 |
+No modules.
 
 ## Resources
 
@@ -144,24 +122,16 @@ You need the following permissions to run this module.
 | <a name="input_archive_type"></a> [archive\_type](#input\_archive\_type) | Specifies the storage class or archive type to which you want the object to transition. Only used if 'create\_cos\_bucket' is true. | `string` | `"Glacier"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name to give the newly provisioned COS bucket. Only required if 'create\_cos\_bucket' is true. | `string` | `null` | no |
 | <a name="input_cos_instance_name"></a> [cos\_instance\_name](#input\_cos\_instance\_name) | The name to give the cloud object storage instance that will be provisioned by this module. Only required if 'create\_cos\_instance' is true. | `string` | `null` | no |
-| <a name="input_cos_key_name"></a> [cos\_key\_name](#input\_cos\_key\_name) | The name of the Key Protect Key to create. This key will be used to encrypt the data in the COS Bucket, and will be created in the specified Key Ring passed to this module using either var.cos\_key\_ring\_name or var.existing\_cos\_key\_ring\_name. | `string` | `"cos-key"` | no |
-| <a name="input_cos_key_ring_name"></a> [cos\_key\_ring\_name](#input\_cos\_key\_ring\_name) | The name of a new Key Ring to create in the Key Protect instance. The Key name specified in var.cos\_key\_name will be created in this Key Ring. | `string` | `"cos-key-ring"` | no |
 | <a name="input_cos_location"></a> [cos\_location](#input\_cos\_location) | Location to provision the cloud object storage instance. Only used if 'create\_cos\_instance' is true. | `string` | `"global"` | no |
 | <a name="input_cos_plan"></a> [cos\_plan](#input\_cos\_plan) | Plan to be used for creating cloud object storage instance. Only used if 'create\_cos\_instance' it true. | `string` | `"standard"` | no |
 | <a name="input_cos_tags"></a> [cos\_tags](#input\_cos\_tags) | Optional list of tags to be added to cloud object storage instance. Only used if 'create\_cos\_instance' it true. | `list(string)` | `[]` | no |
 | <a name="input_create_cos_bucket"></a> [create\_cos\_bucket](#input\_create\_cos\_bucket) | Set as true to create a new Cloud Object Storage bucket | `bool` | `true` | no |
 | <a name="input_create_cos_instance"></a> [create\_cos\_instance](#input\_create\_cos\_instance) | Set as true to create a new Cloud Object Storage instance. | `bool` | `true` | no |
-| <a name="input_create_key_protect_instance"></a> [create\_key\_protect\_instance](#input\_create\_key\_protect\_instance) | Set as true to create a new Key Protect instance. This instance will store the Key used to encrypt the data in the COS Bucket | `bool` | `true` | no |
-| <a name="input_create_key_protect_key"></a> [create\_key\_protect\_key](#input\_create\_key\_protect\_key) | Set as true to create a new Key Protect Key. This key is used to encrypt the COS Bucket | `bool` | `true` | no |
-| <a name="input_enable_key_protect_metrics"></a> [enable\_key\_protect\_metrics](#input\_enable\_key\_protect\_metrics) | Enable Key Protect metrics. Only used if if 'var.create\_key\_protect\_instance' is true. | `string` | `true` | no |
-| <a name="input_encryption_enabled"></a> [encryption\_enabled](#input\_encryption\_enabled) | Set as true to use Key Protect encryption to encrypt data in COS bucket | `bool` | `true` | no |
+| <a name="input_encryption_enabled"></a> [encryption\_enabled](#input\_encryption\_enabled) | Set as true to use Key Protect encryption to encrypt data in COS bucket (only applicable when var.create\_cos\_bucket is true). | `bool` | `true` | no |
 | <a name="input_existing_cos_instance_id"></a> [existing\_cos\_instance\_id](#input\_existing\_cos\_instance\_id) | The ID of an existing cloud object storage instance. Required if 'var.create\_cos\_instance' is false. | `string` | `null` | no |
-| <a name="input_existing_cos_key_ring_name"></a> [existing\_cos\_key\_ring\_name](#input\_existing\_cos\_key\_ring\_name) | The name of an existing Key Ring in which to create the new Key specified in var.cos\_key\_name | `string` | `null` | no |
-| <a name="input_existing_key_protect_instance_guid"></a> [existing\_key\_protect\_instance\_guid](#input\_existing\_key\_protect\_instance\_guid) | The GUID of an existing Key Protect instance. Required if 'var.create\_key\_protect\_instance' is false. | `string` | `null` | no |
+| <a name="input_existing_key_protect_instance_guid"></a> [existing\_key\_protect\_instance\_guid](#input\_existing\_key\_protect\_instance\_guid) | The GUID of the Key Protect instance in which the key specified in var.key\_protect\_key\_crn is coming from. Required if var.create\_cos\_instance is true in order to create an IAM Access Policy to allow Key protect to access the newly created COS instance. | `string` | `null` | no |
 | <a name="input_expire_days"></a> [expire\_days](#input\_expire\_days) | Specifies the number of days when the expire rule action takes effect. Only used if 'create\_cos\_bucket' is true. | `number` | `365` | no |
-| <a name="input_key_protect_instance_name"></a> [key\_protect\_instance\_name](#input\_key\_protect\_instance\_name) | The name to give the Key Protect instance that will be provisioned by this module. Required if 'var.create\_key\_protect\_instance' is true | `string` | `null` | no |
-| <a name="input_key_protect_key_crn"></a> [key\_protect\_key\_crn](#input\_key\_protect\_key\_crn) | CRN of the Key Protect Key to use if not creating a Key in this module, this Key Protect Key is used to encrypt the data in the COS Bucket | `string` | `null` | no |
-| <a name="input_key_protect_tags"></a> [key\_protect\_tags](#input\_key\_protect\_tags) | Optional list of tags to be added to Key Protect instance. Only used if 'var.create\_key\_protect\_instance' is true. | `list(string)` | `[]` | no |
+| <a name="input_key_protect_key_crn"></a> [key\_protect\_key\_crn](#input\_key\_protect\_key\_crn) | CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption\_enabled and var.create\_cos\_bucket are true. | `string` | `null` | no |
 | <a name="input_object_versioning_enabled"></a> [object\_versioning\_enabled](#input\_object\_versioning\_enabled) | Enable object versioning to keep multiple versions of an object in a bucket. Cannot be used with retention rule. Only used if 'create\_cos\_bucket' is true. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region to provision COS bucket. Also used when creating Key Protect / Key Protect Keys for encryption. NOTE: If 'var.encryption\_enabled' is true and an existing Key Protect instance is passed in using 'var.existing\_key\_protect\_instance\_guid', this must be the region of the existing Key Protect instance. | `string` | `"us-south"` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where resources will be provisioned. | `string` | n/a | yes |
@@ -179,7 +149,6 @@ You need the following permissions to run this module.
 | <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | Bucket id |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Bucket Name |
 | <a name="output_cos_instance_id"></a> [cos\_instance\_id](#output\_cos\_instance\_id) | The ID of the Cloud Object Storage Instance where the buckets are created |
-| <a name="output_key_protect_instance_guid"></a> [key\_protect\_instance\_guid](#output\_key\_protect\_instance\_guid) | The GUID of the Key Protect Instance where the Key to encrypt the COS Bucket is stored |
 | <a name="output_key_protect_key_crn"></a> [key\_protect\_key\_crn](#output\_key\_protect\_key\_crn) | The CRN of the Key Protect Key used to encrypt the COS Bucket |
 | <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | Resource Group ID |
 | <a name="output_s3_endpoint_private"></a> [s3\_endpoint\_private](#output\_s3\_endpoint\_private) | S3 private endpoint |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,8 +1,3 @@
-output "key_protect_instance_id" {
-  description = "The GUID of the Key Protect Instance where the Key to encrypt the COS Bucket is stored"
-  value       = module.cos_bucket1.key_protect_instance_guid
-}
-
 output "bucket_name1" {
   description = "Bucket Name"
   value       = module.cos_bucket1.bucket_name

--- a/examples/complete/providers.tf
+++ b/examples/complete/providers.tf
@@ -9,7 +9,7 @@ provider "restapi" {
   debug                 = false # set to true to show detailed logs, but use carefully as it might print sensitive values.
   headers = {
     Authorization    = data.ibm_iam_auth_token.token_data.iam_access_token
-    Bluemix-Instance = module.cos_bucket1.key_protect_instance_guid
+    Bluemix-Instance = module.key_protect_all_inclusive.key_protect_guid
     Content-Type     = "application/vnd.ibm.kms.policy+json"
   }
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -6,9 +6,10 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = "1.49.0"
     }
+    # The restapi provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
     restapi = {
       source  = "Mastercard/restapi"
-      version = "1.18.0"
+      version = ">= 1.18.0"
     }
   }
 }

--- a/examples/existing-resources/README.md
+++ b/examples/existing-resources/README.md
@@ -2,7 +2,7 @@
 
 An end-to-end example that will:
 - Create a new resource group (if existing one is not passed in).
-- Create a new Key Protect instance, Key Ring, and Key in the given resource group and region outside of the terraform-ibm-cos module.
-- Create a new Cloud Object Storage instance in the given resource group and region outside of the terraform-ibm-cos module.
+- Create a new Key Protect instance, Key Ring, and Key in the given resource group and region.
+- Using the terraform-ibm-cos module, create a new Cloud Object Storage instance in the given resource group and region (with no buckets).
 - Create an IAM Access Policy to allow Key Protect to access COS instance (outside of the terraform-ibm-cos module).
 - Using the terraform-ibm-cos module, create a COS Bucket without encryption using the existing COS instance, Key Protect instance + Keys created at the start of this example.

--- a/examples/existing-resources/main.tf
+++ b/examples/existing-resources/main.tf
@@ -35,20 +35,12 @@ module "key_protect_all_inclusive" {
 ##############################################################################
 
 module "cos_instance" {
-  source            = "../../"
-  cos_instance_name = "${var.prefix}-cos"
-  create_cos_bucket = false
-  resource_group_id = module.resource_group.resource_group_id
-  region            = var.region
-}
-
-# Create IAM Access Policy to allow Key protect to access COS instance
-resource "ibm_iam_authorization_policy" "policy" {
-  source_service_name         = "cloud-object-storage"
-  source_resource_instance_id = module.cos_instance.cos_instance_id
-  target_service_name         = "kms"
-  target_resource_instance_id = module.key_protect_all_inclusive.key_protect_guid
-  roles                       = ["Reader"]
+  source                             = "../../"
+  cos_instance_name                  = "${var.prefix}-cos"
+  create_cos_bucket                  = false
+  resource_group_id                  = module.resource_group.resource_group_id
+  existing_key_protect_instance_guid = module.key_protect_all_inclusive.key_protect_guid
+  region                             = var.region
 }
 
 ##############################################################################
@@ -62,6 +54,7 @@ resource "ibm_iam_authorization_policy" "policy" {
 
 module "cos" {
   source                   = "../../"
+  create_cos_instance      = false
   existing_cos_instance_id = module.cos_instance.cos_instance_id
   key_protect_key_crn      = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].crn
   bucket_name              = "${var.prefix}-bucket"

--- a/examples/existing-resources/version.tf
+++ b/examples/existing-resources/version.tf
@@ -6,9 +6,10 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = "1.49.0"
     }
+    # The restapi provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
     restapi = {
       source  = "Mastercard/restapi"
-      version = "1.18.0"
+      version = ">= 1.18.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -12,63 +12,19 @@ locals {
   retention_enabled         = var.retention_enabled ? [1] : []
   object_versioning_enabled = var.object_versioning_enabled ? [1] : []
 
-  # ensure if create_cos_bucket = true, then bucket_name is provided
-  bucket_validate_condition = (var.create_cos_bucket && var.bucket_name == null)
-  bucket_validate_msg       = "If create_cos_bucket is true, then provide value for bucket_name"
+  # input variable validation
   # tflint-ignore: terraform_unused_declarations
-  bucket_validate_check = regex("^${local.bucket_validate_msg}$", (!local.bucket_validate_condition ? local.bucket_validate_msg : ""))
-
-  # ensure if create_cos_instance = true, then cos_instance_name is provided
-  cos_validate_condition = (var.create_cos_instance && var.cos_instance_name == null)
-  cos_validate_msg       = "If create_cos_instance is true, then provide value for cos_instance_name"
+  validate_encryption_inputs = !var.create_cos_instance && !var.create_cos_bucket ? tobool("var.create_cos_instance and var.create_cos_bucket cannot be both set to false") : true
   # tflint-ignore: terraform_unused_declarations
-  cos_validate_check = regex("^${local.cos_validate_msg}$", (!local.cos_validate_condition ? local.cos_validate_msg : ""))
-
-  # ensure if create_cos_instance = false, then existing_cos_instance_id is provided
-  cos_id_validate_condition = (!var.create_cos_instance && var.existing_cos_instance_id == null)
-  cos_id_validate_msg       = "If create_cos_instance is false, then provide the existing_cos_instance_id to create buckets"
+  validate_key_inputs = var.create_cos_bucket && var.encryption_enabled && var.key_protect_key_crn == null ? tobool("A value must be passed for var.key_protect_key_crn when both var.create_cos_bucket and var.encryption_enabled are true") : true
   # tflint-ignore: terraform_unused_declarations
-  cos_id_validate_check = regex("^${local.cos_id_validate_msg}$", (!local.cos_id_validate_condition ? local.cos_id_validate_msg : ""))
-
-  # only allow var.create_key_protect_key or var.key_protect_key_crn to be passed
-  kp_key_validate_condition = var.encryption_enabled && ((var.create_key_protect_key && var.key_protect_key_crn != null) || (!var.create_key_protect_key && var.key_protect_key_crn == null))
-  kp_key_validate_msg       = "Value for 'create_key_protect_key' cannot be true if 'key_protect_key_crn' is not null"
+  validate_bucket_inputs = var.create_cos_bucket && var.bucket_name == null ? tobool("If var.create_cos_bucket is true, then provide value for var.bucket_name") : true
   # tflint-ignore: terraform_unused_declarations
-  kp_key_validate_check = regex("^${local.kp_key_validate_msg}$", (!local.kp_key_validate_condition ? local.kp_key_validate_msg : ""))
-
-  # ensure if key_protect_key_crn is passed then create_key_protect_instance is false
-  kp_key_instance_validate_condition = var.encryption_enabled && (var.key_protect_key_crn != null && var.create_key_protect_instance)
-  kp_key_instance_validate_msg       = "Value for 'key_protect_key_crn' must be null if instance is created by the module"
+  validate_cos_inputs = var.create_cos_instance && var.cos_instance_name == null ? tobool("If var.create_cos_instance is true, then provide value for var.cos_instance_name") : true
   # tflint-ignore: terraform_unused_declarations
-  kp_key_instance_validate_check = regex("^${local.kp_key_instance_validate_msg}$", (!local.kp_key_instance_validate_condition ? local.kp_key_instance_validate_msg : ""))
-
-  # when encryption enabled and creating a new key, ensure a value is passed for either 'var.cos_key_ring_name' or 'var.existing_cos_key_ring_name', but not both
-  key_ring_validate_condition = (var.create_key_protect_key && var.encryption_enabled) && ((var.cos_key_ring_name == null && var.existing_cos_key_ring_name == null) || (var.cos_key_ring_name != null && var.existing_cos_key_ring_name != null))
-  key_ring_validate_msg       = "When enabling encryption and 'var.create_key_protect_key' is true, a value must be passed for either 'var.cos_key_ring_name' or 'var.existing_cos_key_ring_name', but not both."
+  validate_cos_id_input = !var.create_cos_instance && var.existing_cos_instance_id == null ? tobool("If var.create_cos_instance is false, then provide a value for var.existing_cos_instance_id to create buckets") : true
   # tflint-ignore: terraform_unused_declarations
-  key_ring_validate_check = regex("^${local.key_ring_validate_msg}$", (!local.key_ring_validate_condition ? local.key_ring_validate_msg : ""))
-
-  key_map          = var.cos_key_ring_name != null ? tomap({ (var.cos_key_ring_name) : tolist([var.cos_key_name]) }) : {}
-  existing_key_map = var.existing_cos_key_ring_name != null ? tomap({ (var.existing_cos_key_ring_name) : tolist([var.cos_key_name]) }) : {}
-
-  key_ring_name = var.cos_key_ring_name != null ? var.cos_key_ring_name : var.existing_cos_key_ring_name
-  key_crn       = (var.encryption_enabled && var.create_key_protect_key) ? module.kp_all_inclusive[0].keys["${local.key_ring_name}.${var.cos_key_name}"].crn : var.key_protect_key_crn
-}
-
-# Module to create key protect instance or create keys if key protect instance is provided.
-# This module will be executed if encryption_enabled is set to true
-module "kp_all_inclusive" {
-  count                              = (var.encryption_enabled && var.create_key_protect_key) ? 1 : 0
-  source                             = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=v3.0.2"
-  resource_group_id                  = var.resource_group_id
-  region                             = var.region
-  key_protect_instance_name          = var.key_protect_instance_name
-  enable_metrics                     = var.enable_key_protect_metrics
-  existing_key_protect_instance_guid = var.existing_key_protect_instance_guid
-  create_key_protect_instance        = var.create_key_protect_instance
-  key_map                            = local.key_map
-  existing_key_map                   = local.existing_key_map
-  resource_tags                      = var.key_protect_tags
+  validate_kp_guid_input = var.encryption_enabled && var.create_cos_instance && var.existing_key_protect_instance_guid == null ? tobool("A value must be passed for var.existing_key_protect_instance_guid when var.create_cos_instance and var.encryption_enabled is true.") : true
 }
 
 # Resource to create COS instance if create_cos_instance is true
@@ -84,7 +40,7 @@ resource "ibm_resource_instance" "cos_instance" {
 
 locals {
   cos_instance_id      = var.create_cos_instance == true ? tolist(ibm_resource_instance.cos_instance[*].id)[0] : var.existing_cos_instance_id
-  create_access_policy = var.encryption_enabled && var.create_key_protect_instance
+  create_access_policy = var.encryption_enabled && var.create_cos_instance
 }
 
 # Create IAM Access Policy to allow Key protect to access COS instance
@@ -93,7 +49,7 @@ resource "ibm_iam_authorization_policy" "policy" {
   source_service_name         = "cloud-object-storage"
   source_resource_instance_id = local.cos_instance_id
   target_service_name         = "kms"
-  target_resource_instance_id = module.kp_all_inclusive[0].key_protect_guid
+  target_resource_instance_id = var.existing_key_protect_instance_guid
   roles                       = ["Reader"]
 }
 
@@ -110,7 +66,7 @@ resource "ibm_cos_bucket" "cos_bucket" {
   resource_instance_id = local.cos_instance_id
   region_location      = var.region
   storage_class        = "standard"
-  key_protect          = local.key_crn
+  key_protect          = var.key_protect_key_crn
   ## This for_each block is NOT a loop to attach to multiple retention blocks.
   ## This block is only used to conditionally add retention block depending on retention is enabled.
   dynamic "retention_rule" {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -58,26 +58,6 @@
         "line": 26
       }
     },
-    "cos_key_name": {
-      "name": "cos_key_name",
-      "type": "string",
-      "description": "The name of the Key Protect Key to create. This key will be used to encrypt the data in the COS Bucket, and will be created in the specified Key Ring passed to this module using either var.cos_key_ring_name or var.existing_cos_key_ring_name.",
-      "default": "cos-key",
-      "pos": {
-        "filename": "variables.tf",
-        "line": 216
-      }
-    },
-    "cos_key_ring_name": {
-      "name": "cos_key_ring_name",
-      "type": "string",
-      "description": "The name of a new Key Ring to create in the Key Protect instance. The Key name specified in var.cos_key_name will be created in this Key Ring.",
-      "default": "cos-key-ring",
-      "pos": {
-        "filename": "variables.tf",
-        "line": 204
-      }
-    },
     "cos_location": {
       "name": "cos_location",
       "type": "string",
@@ -151,55 +131,18 @@
         "line": 20
       }
     },
-    "create_key_protect_instance": {
-      "name": "create_key_protect_instance",
+    "encryption_enabled": {
+      "name": "encryption_enabled",
       "type": "bool",
-      "description": "Set as true to create a new Key Protect instance. This instance will store the Key used to encrypt the data in the COS Bucket",
+      "description": "Set as true to use Key Protect encryption to encrypt data in COS bucket (only applicable when var.create_cos_bucket is true).",
       "default": true,
       "source": [
-        "module.kp_all_inclusive.module.key_protect"
+        "ibm_cos_bucket.cos_bucket.count",
+        "ibm_cos_bucket.cos_bucket1.count"
       ],
       "pos": {
         "filename": "variables.tf",
         "line": 168
-      }
-    },
-    "create_key_protect_key": {
-      "name": "create_key_protect_key",
-      "type": "bool",
-      "description": "Set as true to create a new Key Protect Key. This key is used to encrypt the COS Bucket",
-      "default": true,
-      "pos": {
-        "filename": "variables.tf",
-        "line": 198
-      }
-    },
-    "enable_key_protect_metrics": {
-      "name": "enable_key_protect_metrics",
-      "type": "string",
-      "description": "Enable Key Protect metrics. Only used if if 'var.create_key_protect_instance' is true.",
-      "default": true,
-      "source": [
-        "module.kp_all_inclusive.module.key_protect.restapi_object.enable_metrics.count"
-      ],
-      "pos": {
-        "filename": "variables.tf",
-        "line": 180
-      }
-    },
-    "encryption_enabled": {
-      "name": "encryption_enabled",
-      "type": "bool",
-      "description": "Set as true to use Key Protect encryption to encrypt data in COS bucket",
-      "default": true,
-      "source": [
-        "ibm_cos_bucket.cos_bucket.count",
-        "ibm_cos_bucket.cos_bucket1.count",
-        "module.kp_all_inclusive"
-      ],
-      "pos": {
-        "filename": "variables.tf",
-        "line": 162
       }
     },
     "existing_cos_instance_id": {
@@ -211,26 +154,19 @@
         "line": 54
       }
     },
-    "existing_cos_key_ring_name": {
-      "name": "existing_cos_key_ring_name",
-      "type": "string",
-      "description": "The name of an existing Key Ring in which to create the new Key specified in var.cos_key_name",
-      "pos": {
-        "filename": "variables.tf",
-        "line": 210
-      }
-    },
     "existing_key_protect_instance_guid": {
       "name": "existing_key_protect_instance_guid",
       "type": "string",
-      "description": "The GUID of an existing Key Protect instance. Required if 'var.create_key_protect_instance' is false.",
+      "description": "The GUID of the Key Protect instance in which the key specified in var.key_protect_key_crn is coming from. Required if var.create_cos_instance is true in order to create an IAM Access Policy to allow Key protect to access the newly created COS instance.",
       "source": [
-        "module.kp_all_inclusive"
+        "ibm_iam_authorization_policy.policy.target_resource_instance_id"
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 186
-      }
+        "line": 162
+      },
+      "immutable": true,
+      "computed": true
     },
     "expire_days": {
       "name": "expire_days",
@@ -242,47 +178,18 @@
         "line": 140
       }
     },
-    "key_protect_instance_name": {
-      "name": "key_protect_instance_name",
+    "key_protect_key_crn": {
+      "name": "key_protect_key_crn",
       "type": "string",
-      "description": "The name to give the Key Protect instance that will be provisioned by this module. Required if 'var.create_key_protect_instance' is true",
-      "required": true,
+      "description": "CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true.",
       "source": [
-        "module.kp_all_inclusive.module.key_protect.ibm_resource_instance.key_protect_instance.name"
+        "ibm_cos_bucket.cos_bucket.key_protect"
       ],
       "pos": {
         "filename": "variables.tf",
         "line": 174
-      }
-    },
-    "key_protect_key_crn": {
-      "name": "key_protect_key_crn",
-      "type": "string",
-      "description": "CRN of the Key Protect Key to use if not creating a Key in this module, this Key Protect Key is used to encrypt the data in the COS Bucket",
-      "pos": {
-        "filename": "variables.tf",
-        "line": 222
-      }
-    },
-    "key_protect_tags": {
-      "name": "key_protect_tags",
-      "type": "list(string)",
-      "description": "Optional list of tags to be added to Key Protect instance. Only used if 'var.create_key_protect_instance' is true.",
-      "default": [],
-      "source": [
-        "module.kp_all_inclusive.module.key_protect.ibm_resource_instance.key_protect_instance.tags"
-      ],
-      "pos": {
-        "filename": "variables.tf",
-        "line": 192
       },
-      "min_length": 1,
-      "max_length": 128,
-      "matches": "^[A-Za-z0-9:_ .-]+$",
-      "computed": true,
-      "elem": {
-        "type": "TypeString"
-      }
+      "immutable": true
     },
     "object_versioning_enabled": {
       "name": "object_versioning_enabled",
@@ -299,22 +206,14 @@
       "type": "string",
       "description": "Region to provision COS bucket. Also used when creating Key Protect / Key Protect Keys for encryption. NOTE: If 'var.encryption_enabled' is true and an existing Key Protect instance is passed in using 'var.existing_key_protect_instance_guid', this must be the region of the existing Key Protect instance.",
       "default": "us-south",
-      "required": true,
       "source": [
         "ibm_cos_bucket.cos_bucket.region_location",
-        "ibm_cos_bucket.cos_bucket1.region_location",
-        "module.kp_all_inclusive.module.key_protect.ibm_resource_instance.key_protect_instance.location",
-        "module.kp_all_inclusive.module.key_protect.restapi_object.enable_metrics.create_path",
-        "module.kp_all_inclusive.module.key_protect.restapi_object.enable_metrics.destroy_path",
-        "module.kp_all_inclusive.module.key_protect.restapi_object.enable_metrics.path",
-        "module.kp_all_inclusive.module.key_protect.restapi_object.enable_metrics.read_path",
-        "module.kp_all_inclusive.module.key_protect.restapi_object.enable_metrics.update_path"
+        "ibm_cos_bucket.cos_bucket1.region_location"
       ],
       "pos": {
         "filename": "variables.tf",
         "line": 10
       },
-      "cloud_data_type": "region",
       "immutable": true
     },
     "resource_group_id": {
@@ -323,8 +222,7 @@
       "description": "The resource group ID where resources will be provisioned.",
       "required": true,
       "source": [
-        "ibm_resource_instance.cos_instance.resource_group_id",
-        "module.kp_all_inclusive.module.key_protect.ibm_resource_instance.key_protect_instance.resource_group_id"
+        "ibm_resource_instance.cos_instance.resource_group_id"
       ],
       "pos": {
         "filename": "variables.tf",
@@ -422,25 +320,18 @@
       "value": "local.cos_instance_id",
       "pos": {
         "filename": "outputs.tf",
-        "line": 39
-      }
-    },
-    "key_protect_instance_guid": {
-      "name": "key_protect_instance_guid",
-      "description": "The GUID of the Key Protect Instance where the Key to encrypt the COS Bucket is stored",
-      "pos": {
-        "filename": "outputs.tf",
-        "line": 29
+        "line": 34
       }
     },
     "key_protect_key_crn": {
       "name": "key_protect_key_crn",
-      "description": "The CRN of the Key Protect Key used to encrypt the COS Bucket",
-      "value": "local.key_crn",
+      "description": "CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true.",
+      "value": "var.key_protect_key_crn",
       "pos": {
         "filename": "outputs.tf",
-        "line": 34
-      }
+        "line": 29
+      },
+      "type": "string"
     },
     "resource_group_id": {
       "name": "resource_group_id",
@@ -484,12 +375,6 @@
       "version_constraints": [
         "\u003e= 1.49.0"
       ]
-    },
-    "restapi": {
-      "source": "Mastercard/restapi",
-      "version_constraints": [
-        "\u003e= 1.18.0"
-      ]
     }
   },
   "managed_resources": {
@@ -500,6 +385,7 @@
       "attributes": {
         "bucket_name": "bucket_name",
         "count": "encryption_enabled",
+        "key_protect": "key_protect_key_crn",
         "region_location": "region"
       },
       "provider": {
@@ -507,7 +393,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 106
+        "line": 62
       }
     },
     "ibm_cos_bucket.cos_bucket1": {
@@ -524,19 +410,22 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 180
+        "line": 136
       }
     },
     "ibm_iam_authorization_policy.policy": {
       "mode": "managed",
       "type": "ibm_iam_authorization_policy",
       "name": "policy",
+      "attributes": {
+        "target_resource_instance_id": "existing_key_protect_instance_guid"
+      },
       "provider": {
         "name": "ibm"
       },
       "pos": {
         "filename": "main.tf",
-        "line": 91
+        "line": 47
       }
     },
     "ibm_resource_instance.cos_instance": {
@@ -556,77 +445,10 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 75
+        "line": 31
       }
     }
   },
   "data_resources": {},
-  "module_calls": {
-    "kp_all_inclusive": {
-      "name": "kp_all_inclusive",
-      "source": "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=v3.0.2",
-      "attributes": {
-        "count": "encryption_enabled",
-        "create_key_protect_instance": "create_key_protect_instance",
-        "enable_metrics": "enable_key_protect_metrics",
-        "existing_key_protect_instance_guid": "existing_key_protect_instance_guid",
-        "key_protect_instance_name": "key_protect_instance_name",
-        "region": "region",
-        "resource_group_id": "resource_group_id",
-        "resource_tags": "key_protect_tags"
-      },
-      "managed_resources": {},
-      "data_resources": {},
-      "outputs": {
-        "existing_key_ring_keys": {
-          "name": "existing_key_ring_keys",
-          "description": "IDs of Keys created by the module in existing Key Rings",
-          "value": "module.existing_key_ring_keys",
-          "pos": {
-            "filename": ".terraform/modules/kp_all_inclusive/outputs.tf",
-            "line": 25
-          }
-        },
-        "key_protect_guid": {
-          "name": "key_protect_guid",
-          "description": "Key Protect GUID",
-          "value": "local.key_protect_guid",
-          "pos": {
-            "filename": ".terraform/modules/kp_all_inclusive/outputs.tf",
-            "line": 5
-          }
-        },
-        "key_protect_name": {
-          "name": "key_protect_name",
-          "description": "Key Protect Name",
-          "pos": {
-            "filename": ".terraform/modules/kp_all_inclusive/outputs.tf",
-            "line": 10
-          }
-        },
-        "key_rings": {
-          "name": "key_rings",
-          "description": "IDs of new Key Rings created by the module",
-          "value": "module.key_protect_key_rings",
-          "pos": {
-            "filename": ".terraform/modules/kp_all_inclusive/outputs.tf",
-            "line": 15
-          }
-        },
-        "keys": {
-          "name": "keys",
-          "description": "IDs of new Keys created by the module",
-          "value": "module.key_protect_keys",
-          "pos": {
-            "filename": ".terraform/modules/kp_all_inclusive/outputs.tf",
-            "line": 20
-          }
-        }
-      },
-      "pos": {
-        "filename": "main.tf",
-        "line": 60
-      }
-    }
-  }
+  "module_calls": {}
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,14 +26,9 @@ output "bucket_name" {
   value       = local.bucket_name
 }
 
-output "key_protect_instance_guid" {
-  description = "The GUID of the Key Protect Instance where the Key to encrypt the COS Bucket is stored"
-  value       = (var.encryption_enabled && var.create_key_protect_key) ? module.kp_all_inclusive[0].key_protect_guid : null
-}
-
 output "key_protect_key_crn" {
   description = "The CRN of the Key Protect Key used to encrypt the COS Bucket"
-  value       = local.key_crn
+  value       = var.key_protect_key_crn
 }
 
 output "cos_instance_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -156,71 +156,23 @@ variable "sysdig_crn" {
 }
 
 ##############################################################################
-# COS encryption variables
+# COS bucket encryption variables
 ##############################################################################
 
-variable "encryption_enabled" {
-  description = "Set as true to use Key Protect encryption to encrypt data in COS bucket"
-  type        = bool
-  default     = true
-}
-
-variable "create_key_protect_instance" {
-  description = "Set as true to create a new Key Protect instance. This instance will store the Key used to encrypt the data in the COS Bucket"
-  type        = bool
-  default     = true
-}
-
-variable "key_protect_instance_name" {
-  description = "The name to give the Key Protect instance that will be provisioned by this module. Required if 'var.create_key_protect_instance' is true"
-  type        = string
-  default     = null
-}
-
-variable "enable_key_protect_metrics" {
-  description = "Enable Key Protect metrics. Only used if if 'var.create_key_protect_instance' is true."
-  type        = string
-  default     = true
-}
-
 variable "existing_key_protect_instance_guid" {
-  description = "The GUID of an existing Key Protect instance. Required if 'var.create_key_protect_instance' is false."
+  description = "The GUID of the Key Protect instance in which the key specified in var.key_protect_key_crn is coming from. Required if var.create_cos_instance is true in order to create an IAM Access Policy to allow Key protect to access the newly created COS instance."
   type        = string
   default     = null
 }
 
-variable "key_protect_tags" {
-  description = "Optional list of tags to be added to Key Protect instance. Only used if 'var.create_key_protect_instance' is true."
-  type        = list(string)
-  default     = []
-}
-
-variable "create_key_protect_key" {
-  description = "Set as true to create a new Key Protect Key. This key is used to encrypt the COS Bucket"
+variable "encryption_enabled" {
+  description = "Set as true to use Key Protect encryption to encrypt data in COS bucket (only applicable when var.create_cos_bucket is true)."
   type        = bool
   default     = true
-}
-
-variable "cos_key_ring_name" {
-  description = "The name of a new Key Ring to create in the Key Protect instance. The Key name specified in var.cos_key_name will be created in this Key Ring."
-  type        = string
-  default     = "cos-key-ring"
-}
-
-variable "existing_cos_key_ring_name" {
-  description = "The name of an existing Key Ring in which to create the new Key specified in var.cos_key_name"
-  type        = string
-  default     = null
-}
-
-variable "cos_key_name" {
-  description = "The name of the Key Protect Key to create. This key will be used to encrypt the data in the COS Bucket, and will be created in the specified Key Ring passed to this module using either var.cos_key_ring_name or var.existing_cos_key_ring_name."
-  type        = string
-  default     = "cos-key"
 }
 
 variable "key_protect_key_crn" {
-  description = "CRN of the Key Protect Key to use if not creating a Key in this module, this Key Protect Key is used to encrypt the data in the COS Bucket"
+  description = "CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true."
   type        = string
   default     = null
 }

--- a/version.tf
+++ b/version.tf
@@ -6,11 +6,5 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = ">= 1.49.0"
     }
-    # ignore linter error, restapi provider needed for key-protect-module/aliases when consuming key-protect-all-inclusive-module
-    #tflint-ignore: terraform_unused_required_providers
-    restapi = {
-      source  = "Mastercard/restapi"
-      version = ">= 1.18.0"
-    }
   }
 }


### PR DESCRIPTION
### Description

- remove direct support for creating key protect instance / key rings / keys from this module (use https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive directly going forward). This will be a major version change due to the may variables that have been removed, and change of outputs

docs:
- update usage to match changes

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
