### PR TITLE
ci: update module.yaml - restapi is no longer required

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -12,7 +12,5 @@ versions:
     providers:
       - name: ibm
         source: "ibm-cloud/ibm"
-      - name: restapi
-        source: "Mastercard/restapi"
     dependencies: []
     variables: []


### PR DESCRIPTION
### Description

update module.yaml - restapi is no longer required

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
