### PR TITLE
fix: add back default value of null for actitivy tracker crn input var

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_activity_tracker_crn"></a> [activity\_tracker\_crn](#input\_activity\_tracker\_crn) | Activity tracker crn for COS bucket (Optional) | `string` | n/a | yes |
+| <a name="input_activity_tracker_crn"></a> [activity\_tracker\_crn](#input\_activity\_tracker\_crn) | Activity tracker crn for COS bucket (Optional) | `string` | `null` | no |
 | <a name="input_archive_days"></a> [archive\_days](#input\_archive\_days) | Specifies the number of days when the archive rule action takes effect. Only used if 'create\_cos\_bucket' is true. This must be set to null when when using var.cross\_region\_location as archive data is not supported with this feature. | `number` | `90` | no |
 | <a name="input_archive_type"></a> [archive\_type](#input\_archive\_type) | Specifies the storage class or archive type to which you want the object to transition. Only used if 'create\_cos\_bucket' is true. | `string` | `"Glacier"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name to give the newly provisioned COS bucket. Only required if 'create\_cos\_bucket' is true. | `string` | `null` | no |

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -5,7 +5,6 @@
       "name": "activity_tracker_crn",
       "type": "string",
       "description": "Activity tracker crn for COS bucket (Optional)",
-      "required": true,
       "pos": {
         "filename": "variables.tf",
         "line": 185
@@ -171,7 +170,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 206
+        "line": 207
       }
     },
     "existing_cos_instance_id": {
@@ -192,7 +191,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 200
+        "line": 201
       },
       "immutable": true,
       "computed": true
@@ -245,7 +244,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 212
+        "line": 213
       },
       "immutable": true
     },
@@ -363,7 +362,7 @@
       "description": "Sysdig Monitoring crn for COS bucket (Optional)",
       "pos": {
         "filename": "variables.tf",
-        "line": 190
+        "line": 191
       }
     }
   },

--- a/variables.tf
+++ b/variables.tf
@@ -185,6 +185,7 @@ variable "expire_days" {
 variable "activity_tracker_crn" {
   type        = string
   description = "Activity tracker crn for COS bucket (Optional)"
+  default     = null
 }
 
 variable "sysdig_crn" {


### PR DESCRIPTION
### Description

In https://github.com/terraform-ibm-modules/terraform-ibm-cos/issues/130 the default value of var.activity_tracker_crn was incorrectly removed.

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
