### PR TITLE
fix: add a count around the deprecation notice for var.service_endpoints so it only triggers if variable is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 This module can be used to provision and configure a [Cloud Object Storage](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-getting-started-cloud-object-storage) instance and/or bucket.
 
 You can configure the following aspects of your instances:
+
 1. [Bucket encryption](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-tutorial-kp-encrypt-bucket) - based on Key Protect keys
 2. [Activity tracking](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-tracking-cos-events) and auditing
 3. [Monitoring](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-monitoring-cos)

--- a/main.tf
+++ b/main.tf
@@ -287,6 +287,7 @@ module "instance_cbr_rule" {
 }
 
 resource "null_resource" "deprecation_notice" {
+  count = var.service_endpoints != null ? 1 : 0
   triggers = {
     always_refresh = timestamp()
   }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -398,7 +398,8 @@
       "description": "(Deprecated) The type of the service endpoint that can be set for the cloud object storage instance.",
       "default": "public-and-private",
       "source": [
-        "ibm_resource_instance.cos_instance.service_endpoints"
+        "ibm_resource_instance.cos_instance.service_endpoints",
+        "null_resource.deprecation_notice.count"
       ],
       "pos": {
         "filename": "variables.tf",
@@ -609,6 +610,9 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "deprecation_notice",
+      "attributes": {
+        "count": "service_endpoints"
+      },
       "provider": {
         "name": "null"
       },


### PR DESCRIPTION
### Description

add a count around the deprecation notice for var.service_endpoints so it only triggers if variable is used

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
