### PR TITLE
fix: add a count around the deprecation notice for var.service_endpoints so it only triggers if variable is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ You need the following permissions to run this module.
 | <a name="input_retention_maximum"></a> [retention\_maximum](#input\_retention\_maximum) | Specifies maximum duration of time an object that can be kept unmodified for COS bucket. Only used if 'create\_cos\_bucket' is true. | `number` | `350` | no |
 | <a name="input_retention_minimum"></a> [retention\_minimum](#input\_retention\_minimum) | Specifies minimum duration of time an object must be kept unmodified for COS bucket. Only used if 'create\_cos\_bucket' is true. | `number` | `90` | no |
 | <a name="input_retention_permanent"></a> [retention\_permanent](#input\_retention\_permanent) | Specifies a permanent retention status either enable or disable for COS bucket. Only used if 'create\_cos\_bucket' is true. | `bool` | `false` | no |
-| <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | (Deprecated) The type of the service endpoint that can be set for the cloud object storage instance. | `string` | `"public-and-private"` | no |
+| <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | (Deprecated) Will be removed in the next major release | `string` | `null` | no |
 | <a name="input_sysdig_crn"></a> [sysdig\_crn](#input\_sysdig\_crn) | Sysdig Monitoring crn for COS bucket (Optional) | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,6 @@ resource "ibm_resource_instance" "cos_instance" {
   plan              = var.cos_plan
   location          = var.cos_location
   tags              = var.cos_tags
-  service_endpoints = var.service_endpoints
 }
 
 resource "ibm_resource_key" "resource_key" {
@@ -287,6 +286,7 @@ module "instance_cbr_rule" {
 }
 
 resource "null_resource" "deprecation_notice" {
+  count = var.service_endpoints != null ? 1 : 0
   triggers = {
     always_refresh = timestamp()
   }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -7,7 +7,7 @@
       "description": "Activity tracker crn for COS bucket (Optional)",
       "pos": {
         "filename": "variables.tf",
-        "line": 195
+        "line": 191
       }
     },
     "archive_days": {
@@ -17,7 +17,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 173
+        "line": 169
       }
     },
     "archive_type": {
@@ -27,7 +27,7 @@
       "default": "Glacier",
       "pos": {
         "filename": "variables.tf",
-        "line": 179
+        "line": 175
       }
     },
     "bucket_cbr_rules": {
@@ -45,7 +45,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 233
+        "line": 229
       }
     },
     "bucket_endpoint": {
@@ -58,7 +58,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 115
+        "line": 111
       },
       "options": "public,private,direct"
     },
@@ -73,7 +73,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 109
+        "line": 105
       },
       "immutable": true
     },
@@ -147,7 +147,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 92
+        "line": 88
       }
     },
     "create_cos_instance": {
@@ -186,7 +186,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 98
+        "line": 94
       },
       "immutable": true,
       "options": "us,eu,ap"
@@ -202,7 +202,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 217
+        "line": 213
       }
     },
     "existing_cos_instance_id": {
@@ -223,7 +223,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 211
+        "line": 207
       },
       "immutable": true,
       "computed": true
@@ -235,7 +235,7 @@
       "default": 365,
       "pos": {
         "filename": "variables.tf",
-        "line": 189
+        "line": 185
       }
     },
     "hmac_key_name": {
@@ -282,7 +282,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 258
+        "line": 254
       }
     },
     "key_protect_key_crn": {
@@ -294,7 +294,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 223
+        "line": 219
       },
       "immutable": true
     },
@@ -305,7 +305,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 167
+        "line": 163
       }
     },
     "region": {
@@ -349,7 +349,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 131
+        "line": 127
       }
     },
     "retention_enabled": {
@@ -359,7 +359,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 125
+        "line": 121
       }
     },
     "retention_maximum": {
@@ -369,7 +369,7 @@
       "default": 350,
       "pos": {
         "filename": "variables.tf",
-        "line": 141
+        "line": 137
       }
     },
     "retention_minimum": {
@@ -379,7 +379,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 151
+        "line": 147
       }
     },
     "retention_permanent": {
@@ -389,22 +389,20 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 161
+        "line": 157
       }
     },
     "service_endpoints": {
       "name": "service_endpoints",
       "type": "string",
-      "description": "(Deprecated) The type of the service endpoint that can be set for the cloud object storage instance.",
-      "default": "public-and-private",
+      "description": "(Deprecated) Will be removed in the next major release",
       "source": [
-        "ibm_resource_instance.cos_instance.service_endpoints"
+        "null_resource.deprecation_notice.count"
       ],
       "pos": {
         "filename": "variables.tf",
         "line": 78
-      },
-      "computed": true
+      }
     },
     "sysdig_crn": {
       "name": "sysdig_crn",
@@ -412,7 +410,7 @@
       "description": "Sysdig Monitoring crn for COS bucket (Optional)",
       "pos": {
         "filename": "variables.tf",
-        "line": 201
+        "line": 197
       }
     }
   },
@@ -530,7 +528,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 77
+        "line": 76
       }
     },
     "ibm_cos_bucket.cos_bucket1": {
@@ -549,7 +547,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 151
+        "line": 150
       }
     },
     "ibm_iam_authorization_policy.policy": {
@@ -564,7 +562,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 61
+        "line": 60
       }
     },
     "ibm_resource_instance.cos_instance": {
@@ -577,7 +575,6 @@
         "name": "cos_instance_name",
         "plan": "cos_plan",
         "resource_group_id": "resource_group_id",
-        "service_endpoints": "service_endpoints",
         "tags": "cos_tags"
       },
       "provider": {
@@ -602,19 +599,22 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 46
+        "line": 45
       }
     },
     "null_resource.deprecation_notice": {
       "mode": "managed",
       "type": "null_resource",
       "name": "deprecation_notice",
+      "attributes": {
+        "count": "service_endpoints"
+      },
       "provider": {
         "name": "null"
       },
       "pos": {
         "filename": "main.tf",
-        "line": 289
+        "line": 288
       }
     }
   },
@@ -678,7 +678,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 216
+        "line": 215
       }
     },
     "instance_cbr_rule": {
@@ -739,7 +739,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 255
+        "line": 254
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -76,13 +76,9 @@ variable "existing_cos_instance_id" {
 }
 
 variable "service_endpoints" {
-  description = "(Deprecated) The type of the service endpoint that can be set for the cloud object storage instance."
+  description = "(Deprecated) Will be removed in the next major release"
   type        = string
-  default     = "public-and-private"
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.service_endpoints)
-    error_message = "The specified service_endpoints is not a valid selection!"
-  }
+  default     = null
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

add a count around the deprecation notice for var.service_endpoints so it only triggers if variable is used

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
