### PR TITLE
fix: clean up un-used ternary expressions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -241,12 +241,7 @@ module "bucket_cbr_rule" {
         operator = "stringEquals"
       }
     ],
-    tags = var.bucket_cbr_rules[count.index].tags != null ? var.bucket_cbr_rules[count.index].tags : [
-      {
-        name  = "terraform-rule"
-        value = "allow-cos-bucket"
-      }
-    ]
+    tags = var.bucket_cbr_rules[count.index].tags
   }]
   operations = var.bucket_cbr_rules[count.index].operations == null ? [] : var.bucket_cbr_rules[count.index].operations
 }

--- a/main.tf
+++ b/main.tf
@@ -275,12 +275,7 @@ module "instance_cbr_rule" {
         operator = "stringEquals"
       }
     ],
-    tags = var.instance_cbr_rules[count.index].tags != null ? var.instance_cbr_rules[count.index].tags : [
-      {
-        name  = "terraform-rule"
-        value = "allow-cos-instance"
-      }
-    ]
+    tags = var.instance_cbr_rules[count.index].tags
   }]
   operations = var.instance_cbr_rules[count.index].operations == null ? [] : var.instance_cbr_rules[count.index].operations
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -614,7 +614,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 288
+        "line": 283
       }
     }
   },

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -614,7 +614,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 283
+        "line": 278
       }
     }
   },
@@ -739,7 +739,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 254
+        "line": 249
       }
     }
   }


### PR DESCRIPTION
### Description

Based on recent changes https://github.com/terraform-ibm-modules/terraform-ibm-cos/pull/205/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR267 these values can never be null. We also do not want to use these default tags

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Clean up un-used ternary expressions
---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
