### PR TITLE
feat: add bucket_storage_class variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ You need the following permissions to run this module.
 | <a name="input_bucket_cbr_rules"></a> [bucket\_cbr\_rules](#input\_bucket\_cbr\_rules) | (Optional, list) List of CBR rules to create for the bucket | <pre>list(object({<br>    description = string<br>    account_id  = string<br>    rule_contexts = list(object({<br>      attributes = optional(list(object({<br>        name  = string<br>        value = string<br>    }))) }))<br>    enforcement_mode = string<br>    tags = optional(list(object({<br>      name  = string<br>      value = string<br>    })), [])<br>    operations = optional(list(object({<br>      api_types = list(object({<br>        api_type_id = string<br>      }))<br>    })))<br>  }))</pre> | `[]` | no |
 | <a name="input_bucket_endpoint"></a> [bucket\_endpoint](#input\_bucket\_endpoint) | The type of endpoint to use for the bucket. (public, private, direct) | `string` | `"public"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name to give the newly provisioned COS bucket. Only required if 'create\_cos\_bucket' is true. | `string` | `null` | no |
+| <a name="input_bucket_storage_class"></a> [bucket\_storage\_class](#input\_bucket\_storage\_class) | the storage class of the newly provisioned COS bucket. Only required if 'create\_cos\_bucket' is true. Supported values are 'standard', 'vault', 'cold', and 'smart'. | `string` | `"standard"` | no |
 | <a name="input_cos_instance_name"></a> [cos\_instance\_name](#input\_cos\_instance\_name) | The name to give the cloud object storage instance that will be provisioned by this module. Only required if 'create\_cos\_instance' is true. | `string` | `null` | no |
 | <a name="input_cos_location"></a> [cos\_location](#input\_cos\_location) | Location to provision the cloud object storage instance. Only used if 'create\_cos\_instance' is true. | `string` | `"global"` | no |
 | <a name="input_cos_plan"></a> [cos\_plan](#input\_cos\_plan) | Plan to be used for creating cloud object storage instance. Only used if 'create\_cos\_instance' it true. | `string` | `"standard"` | no |
@@ -157,6 +158,7 @@ You need the following permissions to run this module.
 |------|-------------|
 | <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | Bucket id |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Bucket Name |
+| <a name="output_bucket_storage_class"></a> [bucket\_storage\_class](#output\_bucket\_storage\_class) | Bucket Storage Class |
 | <a name="output_cos_instance_guid"></a> [cos\_instance\_guid](#output\_cos\_instance\_guid) | The GUID of the Cloud Object Storage Instance where the buckets are created |
 | <a name="output_cos_instance_id"></a> [cos\_instance\_id](#output\_cos\_instance\_id) | The ID of the Cloud Object Storage Instance where the buckets are created |
 | <a name="output_key_protect_key_crn"></a> [key\_protect\_key\_crn](#output\_key\_protect\_key\_crn) | The CRN of the Key Protect Key used to encrypt the COS Bucket |

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ resource "ibm_cos_bucket" "cos_bucket" {
   resource_instance_id  = local.cos_instance_id
   region_location       = var.region
   cross_region_location = var.cross_region_location
-  storage_class         = "standard"
+  storage_class         = var.bucket_storage_class
   key_protect           = var.key_protect_key_crn
   ## This for_each block is NOT a loop to attach to multiple retention blocks.
   ## This block is only used to conditionally add retention block depending on retention is enabled.
@@ -154,7 +154,7 @@ resource "ibm_cos_bucket" "cos_bucket1" {
   region_location       = var.region
   cross_region_location = var.cross_region_location
   endpoint_type         = var.bucket_endpoint
-  storage_class         = "standard"
+  storage_class         = var.bucket_storage_class
   dynamic "retention_rule" {
     for_each = local.retention_enabled
     content {
@@ -202,10 +202,11 @@ resource "ibm_cos_bucket" "cos_bucket1" {
 }
 
 locals {
-  bucket_id           = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].id : ibm_cos_bucket.cos_bucket1[*].id
-  bucket_name         = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].bucket_name : ibm_cos_bucket.cos_bucket1[*].bucket_name
-  s3_endpoint_public  = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].s3_endpoint_public : ibm_cos_bucket.cos_bucket1[*].s3_endpoint_public
-  s3_endpoint_private = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].s3_endpoint_private : ibm_cos_bucket.cos_bucket1[*].s3_endpoint_private
+  bucket_id            = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].id : ibm_cos_bucket.cos_bucket1[*].id
+  bucket_name          = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].bucket_name : ibm_cos_bucket.cos_bucket1[*].bucket_name
+  bucket_storage_class = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].storage_class : ibm_cos_bucket.cos_bucket1[*].storage_class
+  s3_endpoint_public   = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].s3_endpoint_public : ibm_cos_bucket.cos_bucket1[*].s3_endpoint_public
+  s3_endpoint_private  = var.encryption_enabled == true ? ibm_cos_bucket.cos_bucket[*].s3_endpoint_private : ibm_cos_bucket.cos_bucket1[*].s3_endpoint_private
 }
 
 ##############################################################################

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -7,7 +7,7 @@
       "description": "Activity tracker crn for COS bucket (Optional)",
       "pos": {
         "filename": "variables.tf",
-        "line": 191
+        "line": 202
       }
     },
     "archive_days": {
@@ -17,7 +17,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 169
+        "line": 180
       }
     },
     "archive_type": {
@@ -27,7 +27,7 @@
       "default": "Glacier",
       "pos": {
         "filename": "variables.tf",
-        "line": 175
+        "line": 186
       }
     },
     "bucket_cbr_rules": {
@@ -45,7 +45,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 229
+        "line": 240
       }
     },
     "bucket_endpoint": {
@@ -58,7 +58,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 111
+        "line": 122
       },
       "options": "public,private,direct"
     },
@@ -76,6 +76,23 @@
         "line": 105
       },
       "immutable": true
+    },
+    "bucket_storage_class": {
+      "name": "bucket_storage_class",
+      "type": "string",
+      "description": "the storage class of the newly provisioned COS bucket. Only required if 'create_cos_bucket' is true. Supported values are 'standard', 'vault', 'cold', and 'smart'.",
+      "default": "standard",
+      "source": [
+        "ibm_cos_bucket.cos_bucket.storage_class",
+        "ibm_cos_bucket.cos_bucket1.storage_class"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 111
+      },
+      "immutable": true,
+      "options": "standard,vault,cold,smart,flex,onerate_active",
+      "computed": true
     },
     "cos_instance_name": {
       "name": "cos_instance_name",
@@ -202,7 +219,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 213
+        "line": 224
       }
     },
     "existing_cos_instance_id": {
@@ -223,7 +240,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 207
+        "line": 218
       },
       "immutable": true,
       "computed": true
@@ -235,7 +252,7 @@
       "default": 365,
       "pos": {
         "filename": "variables.tf",
-        "line": 185
+        "line": 196
       }
     },
     "hmac_key_name": {
@@ -282,7 +299,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 254
+        "line": 265
       }
     },
     "key_protect_key_crn": {
@@ -294,7 +311,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 219
+        "line": 230
       },
       "immutable": true
     },
@@ -305,7 +322,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 163
+        "line": 174
       }
     },
     "region": {
@@ -349,7 +366,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 127
+        "line": 138
       }
     },
     "retention_enabled": {
@@ -359,7 +376,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 121
+        "line": 132
       }
     },
     "retention_maximum": {
@@ -369,7 +386,7 @@
       "default": 350,
       "pos": {
         "filename": "variables.tf",
-        "line": 137
+        "line": 148
       }
     },
     "retention_minimum": {
@@ -379,7 +396,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 147
+        "line": 158
       }
     },
     "retention_permanent": {
@@ -389,7 +406,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 157
+        "line": 168
       }
     },
     "service_endpoints": {
@@ -410,7 +427,7 @@
       "description": "Sysdig Monitoring crn for COS bucket (Optional)",
       "pos": {
         "filename": "variables.tf",
-        "line": 197
+        "line": 208
       }
     }
   },
@@ -433,13 +450,22 @@
         "line": 24
       }
     },
+    "bucket_storage_class": {
+      "name": "bucket_storage_class",
+      "description": "Bucket Storage Class",
+      "value": "local.bucket_storage_class",
+      "pos": {
+        "filename": "outputs.tf",
+        "line": 29
+      }
+    },
     "cos_instance_guid": {
       "name": "cos_instance_guid",
       "description": "The GUID of the Cloud Object Storage Instance where the buckets are created",
       "value": "local.cos_instance_guid",
       "pos": {
         "filename": "outputs.tf",
-        "line": 39
+        "line": 44
       }
     },
     "cos_instance_id": {
@@ -448,7 +474,7 @@
       "value": "local.cos_instance_id",
       "pos": {
         "filename": "outputs.tf",
-        "line": 34
+        "line": 39
       }
     },
     "key_protect_key_crn": {
@@ -457,7 +483,7 @@
       "value": "var.key_protect_key_crn",
       "pos": {
         "filename": "outputs.tf",
-        "line": 29
+        "line": 34
       },
       "type": "string"
     },
@@ -521,7 +547,8 @@
         "count": "encryption_enabled",
         "cross_region_location": "cross_region_location",
         "key_protect": "key_protect_key_crn",
-        "region_location": "region"
+        "region_location": "region",
+        "storage_class": "bucket_storage_class"
       },
       "provider": {
         "name": "ibm"
@@ -540,7 +567,8 @@
         "count": "encryption_enabled",
         "cross_region_location": "cross_region_location",
         "endpoint_type": "bucket_endpoint",
-        "region_location": "region"
+        "region_location": "region",
+        "storage_class": "bucket_storage_class"
       },
       "provider": {
         "name": "ibm"
@@ -614,7 +642,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 278
+        "line": 279
       }
     }
   },
@@ -678,7 +706,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 215
+        "line": 216
       }
     },
     "instance_cbr_rule": {
@@ -739,7 +767,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 249
+        "line": 250
       }
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,11 @@ output "bucket_name" {
   value       = local.bucket_name
 }
 
+output "bucket_storage_class" {
+  description = "Bucket Storage Class"
+  value       = local.bucket_storage_class
+}
+
 output "key_protect_key_crn" {
   description = "The CRN of the Key Protect Key used to encrypt the COS Bucket"
   value       = var.key_protect_key_crn

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,17 @@ variable "bucket_name" {
   default     = null
 }
 
+variable "bucket_storage_class" {
+  type        = string
+  description = "the storage class of the newly provisioned COS bucket. Only required if 'create_cos_bucket' is true. Supported values are 'standard', 'vault', 'cold', and 'smart'."
+  default     = "standard"
+
+  validation {
+    condition     = can(regex("^standard$|^vault$|^cold$|^smart$", var.bucket_storage_class))
+    error_message = "Variable 'bucket_storage_class' must be 'standard', 'vault', 'cold', or 'smart'."
+  }
+}
+
 variable "bucket_endpoint" {
   description = "The type of endpoint to use for the bucket. (public, private, direct)"
   type        = string


### PR DESCRIPTION
### Description
Add bucket_storage_class variable to allow users to select their storage class type, add validation for the variable to ensure proper value is passed, default set to "standard" to stay in line with previous versions of the module.

Git Issue: https://github.com/terraform-ibm-modules/terraform-ibm-cos/issues/209

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [x] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Add variable `var.bucket_storage_class` to allow selection of available storage classes for buckets created by the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
