### PR TITLE
fix: complete example must restrict region

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -21,6 +21,11 @@ variable "region" {
   description = "Region where resources will be created"
   type        = string
   default     = "us-south"
+
+  validation {
+    condition     = can(regex("us-south|eu-de|jp-tok", var.region))
+    error_message = "Variable 'region' must be 'us-south' or 'eu-de', or 'jp-tok'. The encryption key must be created in a high availability key protect instance for cross region object storage"
+  }
 }
 
 variable "cross_region_location" {


### PR DESCRIPTION
### Description

Update the complete example to restrict the region selection (for Key Protect instance and key) to a region that supports high availability. This is required to support cross region object storage high availability model.
The test already forces the region to us_south, so the test should always pass. This change should cause the `complete` example to fail locally at the terraform plan phase if an unsupported region is selected.

Issue #200

### Types of changes in this PR

#### No release required

- [x] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [x] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
