### PR TITLE
fix: remove endpoints and rename kms

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ module "cos_module" {
   region                             = "us-south"
   cos_instance_name                  = "my-cos-instance"
   bucket_name                        = "my-cos-bucket"
-  existing_key_protect_instance_guid = "xxxxxxxx-XXXX-XXXX-XXXX-xxxxxxxx"
-  key_protect_key_crn                = "crn:v1:bluemix:public:kms:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxxxxx-XXXX-XXXX-XXXX-xxxxxx:key:xxxxxx-XXXX-XXXX-XXXX-xxxxxx"
+  existing_kms_instance_guid = "xxxxxxxx-XXXX-XXXX-XXXX-xxxxxxxx"
+  kms_key_crn                = "crn:v1:bluemix:public:kms:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxxxxx-XXXX-XXXX-XXXX-xxxxxx:key:xxxxxx-XXXX-XXXX-XXXX-xxxxxx"
   sysdig_crn                         = "crn:v1:bluemix:public:sysdig-monitor:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
   activity_tracker_crn               = "crn:v1:bluemix:public:logdnaat:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
 }
@@ -49,7 +49,7 @@ module "additional_cos_bucket" {
   sysdig_crn                         = "crn:v1:bluemix:public:sysdig-monitor:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
   activity_tracker_crn               = "crn:v1:bluemix:public:logdnaat:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX::"
   existing_cos_instance_id           = module.cos_module.cos_instance_id
-  key_protect_key_crn                = "crn:v1:bluemix:public:kms:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxxxxx-XXXX-XXXX-XXXX-xxxxxx:key:xxxxxx-XXXX-XXXX-XXXX-xxxxxx"
+  kms_key_crn                = "crn:v1:bluemix:public:kms:us-south:a/xxXXxxXXxXxXXXXxxXxxxXXXXxXXXXX:xxxxxx-XXXX-XXXX-XXXX-xxxxxx:key:xxxxxx-XXXX-XXXX-XXXX-xxxxxx"
 }
 ```
 
@@ -101,7 +101,6 @@ You need the following permissions to run this module.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.51.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >=3.2.1 |
 
 ## Modules
 
@@ -119,7 +118,6 @@ You need the following permissions to run this module.
 | [ibm_iam_authorization_policy.policy](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/iam_authorization_policy) | resource |
 | [ibm_resource_instance.cos_instance](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/resource_instance) | resource |
 | [ibm_resource_key.resource_key](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/resource_key) | resource |
-| [null_resource.deprecation_notice](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 
@@ -129,7 +127,6 @@ You need the following permissions to run this module.
 | <a name="input_archive_days"></a> [archive\_days](#input\_archive\_days) | Specifies the number of days when the archive rule action takes effect. Only used if 'create\_cos\_bucket' is true. This must be set to null when when using var.cross\_region\_location as archive data is not supported with this feature. | `number` | `90` | no |
 | <a name="input_archive_type"></a> [archive\_type](#input\_archive\_type) | Specifies the storage class or archive type to which you want the object to transition. Only used if 'create\_cos\_bucket' is true. | `string` | `"Glacier"` | no |
 | <a name="input_bucket_cbr_rules"></a> [bucket\_cbr\_rules](#input\_bucket\_cbr\_rules) | (Optional, list) List of CBR rules to create for the bucket | <pre>list(object({<br>    description = string<br>    account_id  = string<br>    rule_contexts = list(object({<br>      attributes = optional(list(object({<br>        name  = string<br>        value = string<br>    }))) }))<br>    enforcement_mode = string<br>    tags = optional(list(object({<br>      name  = string<br>      value = string<br>    })), [])<br>    operations = optional(list(object({<br>      api_types = list(object({<br>        api_type_id = string<br>      }))<br>    })))<br>  }))</pre> | `[]` | no |
-| <a name="input_bucket_endpoint"></a> [bucket\_endpoint](#input\_bucket\_endpoint) | The type of endpoint to use for the bucket. (public, private, direct). Provider issue 4357 reports that private does not work | `string` | `"public"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name to give the newly provisioned COS bucket. Only required if 'create\_cos\_bucket' is true. | `string` | `null` | no |
 | <a name="input_bucket_storage_class"></a> [bucket\_storage\_class](#input\_bucket\_storage\_class) | the storage class of the newly provisioned COS bucket. Only required if 'create\_cos\_bucket' is true. Supported values are 'standard', 'vault', 'cold', and 'smart'. | `string` | `"standard"` | no |
 | <a name="input_cos_instance_name"></a> [cos\_instance\_name](#input\_cos\_instance\_name) | The name to give the cloud object storage instance that will be provisioned by this module. Only required if 'create\_cos\_instance' is true. | `string` | `null` | no |
@@ -140,14 +137,14 @@ You need the following permissions to run this module.
 | <a name="input_create_cos_instance"></a> [create\_cos\_instance](#input\_create\_cos\_instance) | Set as true to create a new Cloud Object Storage instance. | `bool` | `true` | no |
 | <a name="input_create_hmac_key"></a> [create\_hmac\_key](#input\_create\_hmac\_key) | Set as true to create a new HMAC key for the Cloud Object Storage instance. | `bool` | `true` | no |
 | <a name="input_cross_region_location"></a> [cross\_region\_location](#input\_cross\_region\_location) | Specify the cross-regional bucket location. Supported values are 'us', 'eu', and 'ap'. If you pass a value for this, ensure to set the value of var.region to null. | `string` | `null` | no |
-| <a name="input_encryption_enabled"></a> [encryption\_enabled](#input\_encryption\_enabled) | Set as true to use Key Protect encryption to encrypt data in COS bucket (only applicable when var.create\_cos\_bucket is true). | `bool` | `true` | no |
+| <a name="input_encryption_enabled"></a> [encryption\_enabled](#input\_encryption\_enabled) | Set as true to use KMS key encryption to encrypt data in COS bucket (only applicable when var.create\_cos\_bucket is true). | `bool` | `true` | no |
 | <a name="input_existing_cos_instance_id"></a> [existing\_cos\_instance\_id](#input\_existing\_cos\_instance\_id) | The ID of an existing cloud object storage instance. Required if 'var.create\_cos\_instance' is false. | `string` | `null` | no |
-| <a name="input_existing_key_protect_instance_guid"></a> [existing\_key\_protect\_instance\_guid](#input\_existing\_key\_protect\_instance\_guid) | The GUID of the Key Protect instance in which the key specified in var.key\_protect\_key\_crn is coming from. Required if var.create\_cos\_instance is true in order to create an IAM Access Policy to allow Key protect to access the newly created COS instance. | `string` | `null` | no |
+| <a name="input_existing_kms_instance_guid"></a> [existing\_kms\_instance\_guid](#input\_existing\_kms\_instance\_guid) | The GUID of the KMS instance in which the key specified in var.kms\_key\_crn is coming from. Required if var.create\_cos\_instance is true in order to create an IAM Access Policy to allow KMS to access the newly created COS instance. | `string` | `null` | no |
 | <a name="input_expire_days"></a> [expire\_days](#input\_expire\_days) | Specifies the number of days when the expire rule action takes effect. Only used if 'create\_cos\_bucket' is true. | `number` | `365` | no |
 | <a name="input_hmac_key_name"></a> [hmac\_key\_name](#input\_hmac\_key\_name) | The name of the hmac key to be created. | `string` | `"hmac-cos-key"` | no |
 | <a name="input_hmac_key_role"></a> [hmac\_key\_role](#input\_hmac\_key\_role) | The role you want to be associated with your new hmac key. Valid roles are 'Writer', 'Reader', 'Manager', 'Content Reader', 'Object Reader', 'Object Writer'. | `string` | `"Manager"` | no |
 | <a name="input_instance_cbr_rules"></a> [instance\_cbr\_rules](#input\_instance\_cbr\_rules) | (Optional, list) List of CBR rules to create for the instance | <pre>list(object({<br>    description = string<br>    account_id  = string<br>    rule_contexts = list(object({<br>      attributes = optional(list(object({<br>        name  = string<br>        value = string<br>    }))) }))<br>    enforcement_mode = string<br>    tags = optional(list(object({<br>      name  = string<br>      value = string<br>    })), [])<br>    operations = optional(list(object({<br>      api_types = list(object({<br>        api_type_id = string<br>      }))<br>    })))<br>  }))</pre> | `[]` | no |
-| <a name="input_key_protect_key_crn"></a> [key\_protect\_key\_crn](#input\_key\_protect\_key\_crn) | CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption\_enabled and var.create\_cos\_bucket are true. | `string` | `null` | no |
+| <a name="input_kms_key_crn"></a> [kms\_key\_crn](#input\_kms\_key\_crn) | CRN of the KMS Key to use to encrypt the data in the COS Bucket. Required if var.encryption\_enabled and var.create\_cos\_bucket are true. | `string` | `null` | no |
 | <a name="input_object_versioning_enabled"></a> [object\_versioning\_enabled](#input\_object\_versioning\_enabled) | Enable object versioning to keep multiple versions of an object in a bucket. Cannot be used with retention rule. Only used if 'create\_cos\_bucket' is true. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region to provision the bucket. If you pass a value for this, do not pass one for var.cross\_region\_location. | `string` | `"us-south"` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where resources will be provisioned. | `string` | n/a | yes |
@@ -157,8 +154,7 @@ You need the following permissions to run this module.
 | <a name="input_retention_maximum"></a> [retention\_maximum](#input\_retention\_maximum) | Specifies maximum duration of time an object that can be kept unmodified for COS bucket. Only used if 'create\_cos\_bucket' is true. | `number` | `350` | no |
 | <a name="input_retention_minimum"></a> [retention\_minimum](#input\_retention\_minimum) | Specifies minimum duration of time an object must be kept unmodified for COS bucket. Only used if 'create\_cos\_bucket' is true. | `number` | `90` | no |
 | <a name="input_retention_permanent"></a> [retention\_permanent](#input\_retention\_permanent) | Specifies a permanent retention status either enable or disable for COS bucket. Only used if 'create\_cos\_bucket' is true. | `bool` | `false` | no |
-| <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | (Deprecated) Will be removed in the next major release | `string` | `null` | no |
-| <a name="input_skip_iam_authorization_policy"></a> [skip\_iam\_authorization\_policy](#input\_skip\_iam\_authorization\_policy) | Set to true to skip the creation of an IAM authorization policy that permits the COS instance created to read the encryption key from the Key Protect instance in `existing_key_protect_instance_guid`. WARNING: An authorization policy must exist before an encrypted bucket can be created | `bool` | `false` | no |
+| <a name="input_skip_iam_authorization_policy"></a> [skip\_iam\_authorization\_policy](#input\_skip\_iam\_authorization\_policy) | Set to true to skip the creation of an IAM authorization policy that permits the COS instance created to read the encryption key from the KMS instance in `existing_kms_instance_guid`. WARNING: An authorization policy must exist before an encrypted bucket can be created | `bool` | `false` | no |
 | <a name="input_sysdig_crn"></a> [sysdig\_crn](#input\_sysdig\_crn) | Sysdig Monitoring crn for COS bucket (Optional) | `string` | `null` | no |
 
 ## Outputs
@@ -171,7 +167,7 @@ You need the following permissions to run this module.
 | <a name="output_bucket_storage_class"></a> [bucket\_storage\_class](#output\_bucket\_storage\_class) | Bucket Storage Class |
 | <a name="output_cos_instance_guid"></a> [cos\_instance\_guid](#output\_cos\_instance\_guid) | The GUID of the Cloud Object Storage Instance where the buckets are created |
 | <a name="output_cos_instance_id"></a> [cos\_instance\_id](#output\_cos\_instance\_id) | The ID of the Cloud Object Storage Instance where the buckets are created |
-| <a name="output_key_protect_key_crn"></a> [key\_protect\_key\_crn](#output\_key\_protect\_key\_crn) | The CRN of the Key Protect Key used to encrypt the COS Bucket |
+| <a name="output_kms_key_crn"></a> [kms\_key\_crn](#output\_kms\_key\_crn) | The CRN of the KMS Key used to encrypt the COS Bucket |
 | <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | Resource Group ID |
 | <a name="output_s3_endpoint_private"></a> [s3\_endpoint\_private](#output\_s3\_endpoint\_private) | S3 private endpoint |
 | <a name="output_s3_endpoint_public"></a> [s3\_endpoint\_public](#output\_s3\_endpoint\_public) | S3 public endpoint |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -105,17 +105,16 @@ module "cbr_zone" {
 # - Monitoring
 # - Activity Tracking
 module "cos_bucket1" {
-  source                             = "../../"
-  resource_group_id                  = module.resource_group.resource_group_id
-  region                             = var.region
-  cross_region_location              = null
-  cos_instance_name                  = "${var.prefix}-cos"
-  cos_tags                           = var.resource_tags
-  bucket_name                        = "${var.prefix}-bucket-1"
-  bucket_endpoint                    = var.bucket_endpoint
-  existing_key_protect_instance_guid = module.key_protect_all_inclusive.key_protect_guid
-  key_protect_key_crn                = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].crn
-  sysdig_crn                         = module.observability_instances.sysdig_crn
+  source                     = "../../"
+  resource_group_id          = module.resource_group.resource_group_id
+  region                     = var.region
+  cross_region_location      = null
+  cos_instance_name          = "${var.prefix}-cos"
+  cos_tags                   = var.resource_tags
+  bucket_name                = "${var.prefix}-bucket-1"
+  existing_kms_instance_guid = module.key_protect_all_inclusive.key_protect_guid
+  kms_key_crn                = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].crn
+  sysdig_crn                 = module.observability_instances.sysdig_crn
   # disable retention for test environments - enable for stage/prod
   retention_enabled    = false
   activity_tracker_crn = local.at_crn
@@ -173,7 +172,6 @@ module "cos_bucket1" {
 module "cos_bucket2" {
   source                   = "../../"
   bucket_name              = "${var.prefix}-bucket-2"
-  bucket_endpoint          = var.bucket_endpoint
   resource_group_id        = module.resource_group.resource_group_id
   region                   = null
   cross_region_location    = var.cross_region_location
@@ -183,8 +181,8 @@ module "cos_bucket2" {
   create_cos_instance      = false
   existing_cos_instance_id = module.cos_bucket1.cos_instance_id
   # disable retention for test environments - enable for stage/prod
-  retention_enabled   = false
-  key_protect_key_crn = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].crn
+  retention_enabled = false
+  kms_key_crn       = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].crn
   bucket_cbr_rules = [
     {
       description      = "sample rule for bucket 2"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -39,12 +39,6 @@ variable "cross_region_location" {
   }
 }
 
-variable "bucket_endpoint" {
-  type        = string
-  description = "Bucket endpoint type"
-  default     = "public"
-}
-
 variable "resource_group" {
   type        = string
   description = "An existing resource group name to use for this example, if unset a new resource group will be created"

--- a/examples/existing-resources/main.tf
+++ b/examples/existing-resources/main.tf
@@ -48,7 +48,7 @@ module "cos_instance" {
   cos_instance_name                   = "${var.prefix}-cos"
   create_cos_bucket                   = false
   resource_group_id                   = module.resource_group.resource_group_id
-  existing_key_protect_instance_guid  = module.key_protect_all_inclusive.key_protect_guid
+  existing_kms_instance_guid          = module.key_protect_all_inclusive.key_protect_guid
   region                              = var.region
   cross_region_location               = null
   activity_tracker_crn                = null
@@ -78,7 +78,7 @@ module "cos" {
   source                   = "../../"
   create_cos_instance      = false
   existing_cos_instance_id = module.cos_instance.cos_instance_id
-  key_protect_key_crn      = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].crn
+  kms_key_crn              = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].crn
   bucket_name              = "${var.prefix}-bucket"
   resource_group_id        = module.resource_group.resource_group_id
   region                   = var.region

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -7,7 +7,7 @@
       "description": "Activity tracker crn for COS bucket (Optional)",
       "pos": {
         "filename": "variables.tf",
-        "line": 208
+        "line": 192
       }
     },
     "archive_days": {
@@ -17,7 +17,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 186
+        "line": 170
       }
     },
     "archive_type": {
@@ -27,7 +27,7 @@
       "default": "Glacier",
       "pos": {
         "filename": "variables.tf",
-        "line": 192
+        "line": 176
       }
     },
     "bucket_cbr_rules": {
@@ -45,23 +45,8 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 246
+        "line": 230
       }
-    },
-    "bucket_endpoint": {
-      "name": "bucket_endpoint",
-      "type": "string",
-      "description": "The type of endpoint to use for the bucket. (public, private, direct). Provider issue 4357 reports that private does not work",
-      "default": "public",
-      "source": [
-        "ibm_cos_bucket.cos_bucket.endpoint_type",
-        "ibm_cos_bucket.cos_bucket1.endpoint_type"
-      ],
-      "pos": {
-        "filename": "variables.tf",
-        "line": 128
-      },
-      "options": "public,private,direct"
     },
     "bucket_name": {
       "name": "bucket_name",
@@ -74,7 +59,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 111
+        "line": 105
       },
       "immutable": true
     },
@@ -89,7 +74,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 117
+        "line": 111
       },
       "immutable": true,
       "options": "standard,vault,cold,smart,flex,onerate_active",
@@ -165,7 +150,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 94
+        "line": 88
       }
     },
     "create_cos_instance": {
@@ -204,7 +189,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 100
+        "line": 94
       },
       "immutable": true,
       "options": "us,eu,ap"
@@ -212,7 +197,7 @@
     "encryption_enabled": {
       "name": "encryption_enabled",
       "type": "bool",
-      "description": "Set as true to use Key Protect encryption to encrypt data in COS bucket (only applicable when var.create_cos_bucket is true).",
+      "description": "Set as true to use KMS key encryption to encrypt data in COS bucket (only applicable when var.create_cos_bucket is true).",
       "default": true,
       "source": [
         "ibm_cos_bucket.cos_bucket.count",
@@ -220,7 +205,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 230
+        "line": 214
       }
     },
     "existing_cos_instance_id": {
@@ -232,16 +217,16 @@
         "line": 78
       }
     },
-    "existing_key_protect_instance_guid": {
-      "name": "existing_key_protect_instance_guid",
+    "existing_kms_instance_guid": {
+      "name": "existing_kms_instance_guid",
       "type": "string",
-      "description": "The GUID of the Key Protect instance in which the key specified in var.key_protect_key_crn is coming from. Required if var.create_cos_instance is true in order to create an IAM Access Policy to allow Key protect to access the newly created COS instance.",
+      "description": "The GUID of the KMS instance in which the key specified in var.kms_key_crn is coming from. Required if var.create_cos_instance is true in order to create an IAM Access Policy to allow KMS to access the newly created COS instance.",
       "source": [
         "ibm_iam_authorization_policy.policy.target_resource_instance_id"
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 224
+        "line": 208
       },
       "immutable": true,
       "computed": true
@@ -253,7 +238,7 @@
       "default": 365,
       "pos": {
         "filename": "variables.tf",
-        "line": 202
+        "line": 186
       }
     },
     "hmac_key_name": {
@@ -300,19 +285,19 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 271
+        "line": 255
       }
     },
-    "key_protect_key_crn": {
-      "name": "key_protect_key_crn",
+    "kms_key_crn": {
+      "name": "kms_key_crn",
       "type": "string",
-      "description": "CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true.",
+      "description": "CRN of the KMS Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true.",
       "source": [
         "ibm_cos_bucket.cos_bucket.key_protect"
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 236
+        "line": 220
       },
       "immutable": true
     },
@@ -323,7 +308,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 180
+        "line": 164
       }
     },
     "region": {
@@ -379,7 +364,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 144
+        "line": 128
       }
     },
     "retention_enabled": {
@@ -389,7 +374,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 138
+        "line": 122
       }
     },
     "retention_maximum": {
@@ -399,7 +384,7 @@
       "default": 350,
       "pos": {
         "filename": "variables.tf",
-        "line": 154
+        "line": 138
       }
     },
     "retention_minimum": {
@@ -409,7 +394,7 @@
       "default": 90,
       "pos": {
         "filename": "variables.tf",
-        "line": 164
+        "line": 148
       }
     },
     "retention_permanent": {
@@ -419,29 +404,17 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 174
-      }
-    },
-    "service_endpoints": {
-      "name": "service_endpoints",
-      "type": "string",
-      "description": "(Deprecated) Will be removed in the next major release",
-      "source": [
-        "null_resource.deprecation_notice.count"
-      ],
-      "pos": {
-        "filename": "variables.tf",
-        "line": 84
+        "line": 158
       }
     },
     "skip_iam_authorization_policy": {
       "name": "skip_iam_authorization_policy",
       "type": "bool",
-      "description": "Set to true to skip the creation of an IAM authorization policy that permits the COS instance created to read the encryption key from the Key Protect instance in `existing_key_protect_instance_guid`. WARNING: An authorization policy must exist before an encrypted bucket can be created",
+      "description": "Set to true to skip the creation of an IAM authorization policy that permits the COS instance created to read the encryption key from the KMS instance in `existing_kms_instance_guid`. WARNING: An authorization policy must exist before an encrypted bucket can be created",
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 296
+        "line": 280
       }
     },
     "sysdig_crn": {
@@ -450,7 +423,7 @@
       "description": "Sysdig Monitoring crn for COS bucket (Optional)",
       "pos": {
         "filename": "variables.tf",
-        "line": 214
+        "line": 198
       }
     }
   },
@@ -509,10 +482,10 @@
         "line": 44
       }
     },
-    "key_protect_key_crn": {
-      "name": "key_protect_key_crn",
-      "description": "CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true.",
-      "value": "var.key_protect_key_crn",
+    "kms_key_crn": {
+      "name": "kms_key_crn",
+      "description": "CRN of the KMS Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true.",
+      "value": "var.kms_key_crn",
       "pos": {
         "filename": "outputs.tf",
         "line": 39
@@ -561,12 +534,6 @@
       "version_constraints": [
         "\u003e= 1.51.0"
       ]
-    },
-    "null": {
-      "source": "hashicorp/null",
-      "version_constraints": [
-        "\u003e=3.2.1"
-      ]
     }
   },
   "managed_resources": {
@@ -578,8 +545,7 @@
         "bucket_name": "bucket_name",
         "count": "encryption_enabled",
         "cross_region_location": "cross_region_location",
-        "endpoint_type": "bucket_endpoint",
-        "key_protect": "key_protect_key_crn",
+        "key_protect": "kms_key_crn",
         "region_location": "region",
         "storage_class": "bucket_storage_class"
       },
@@ -599,7 +565,6 @@
         "bucket_name": "bucket_name",
         "count": "encryption_enabled",
         "cross_region_location": "cross_region_location",
-        "endpoint_type": "bucket_endpoint",
         "region_location": "region",
         "storage_class": "bucket_storage_class"
       },
@@ -608,7 +573,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 156
+        "line": 155
       }
     },
     "ibm_iam_authorization_policy.policy": {
@@ -616,7 +581,7 @@
       "type": "ibm_iam_authorization_policy",
       "name": "policy",
       "attributes": {
-        "target_resource_instance_id": "existing_key_protect_instance_guid"
+        "target_resource_instance_id": "existing_kms_instance_guid"
       },
       "provider": {
         "name": "ibm"
@@ -662,21 +627,6 @@
       "pos": {
         "filename": "main.tf",
         "line": 45
-      }
-    },
-    "null_resource.deprecation_notice": {
-      "mode": "managed",
-      "type": "null_resource",
-      "name": "deprecation_notice",
-      "attributes": {
-        "count": "service_endpoints"
-      },
-      "provider": {
-        "name": "null"
-      },
-      "pos": {
-        "filename": "main.tf",
-        "line": 294
       }
     }
   },
@@ -756,7 +706,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 231
+        "line": 229
       }
     },
     "instance_cbr_rule": {
@@ -833,7 +783,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 265
+        "line": 263
       }
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,9 +36,9 @@ output "bucket_storage_class" {
   value       = local.bucket_storage_class
 }
 
-output "key_protect_key_crn" {
-  description = "The CRN of the Key Protect Key used to encrypt the COS Bucket"
-  value       = var.key_protect_key_crn
+output "kms_key_crn" {
+  description = "The CRN of the KMS Key used to encrypt the COS Bucket"
+  value       = var.kms_key_crn
 }
 
 output "cos_instance_id" {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -77,7 +77,6 @@ func TestRunCompleteExample(t *testing.T) {
 	t.Parallel()
 
 	options := setupOptions(t, "cos-complete", completeExampleTerraformDir)
-	options.TerraformVars["bucket_endpoint"] = "public" // provider issue 4357
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")

--- a/variables.tf
+++ b/variables.tf
@@ -81,12 +81,6 @@ variable "existing_cos_instance_id" {
   default     = null
 }
 
-variable "service_endpoints" {
-  description = "(Deprecated) Will be removed in the next major release"
-  type        = string
-  default     = null
-}
-
 ##############################################################################
 # COS bucket variables
 ##############################################################################
@@ -122,16 +116,6 @@ variable "bucket_storage_class" {
   validation {
     condition     = can(regex("^standard$|^vault$|^cold$|^smart$", var.bucket_storage_class))
     error_message = "Variable 'bucket_storage_class' must be 'standard', 'vault', 'cold', or 'smart'."
-  }
-}
-
-variable "bucket_endpoint" {
-  description = "The type of endpoint to use for the bucket. (public, private, direct). Provider issue 4357 reports that private does not work"
-  type        = string
-  default     = "public"
-  validation {
-    condition     = contains(["public", "private", "direct"], var.bucket_endpoint)
-    error_message = "The specified bucket_endpoint is not a valid selection!"
   }
 }
 
@@ -221,20 +205,20 @@ variable "sysdig_crn" {
 # COS bucket encryption variables
 ##############################################################################
 
-variable "existing_key_protect_instance_guid" {
-  description = "The GUID of the Key Protect instance in which the key specified in var.key_protect_key_crn is coming from. Required if var.create_cos_instance is true in order to create an IAM Access Policy to allow Key protect to access the newly created COS instance."
+variable "existing_kms_instance_guid" {
+  description = "The GUID of the KMS instance in which the key specified in var.kms_key_crn is coming from. Required if var.create_cos_instance is true in order to create an IAM Access Policy to allow KMS to access the newly created COS instance."
   type        = string
   default     = null
 }
 
 variable "encryption_enabled" {
-  description = "Set as true to use Key Protect encryption to encrypt data in COS bucket (only applicable when var.create_cos_bucket is true)."
+  description = "Set as true to use KMS key encryption to encrypt data in COS bucket (only applicable when var.create_cos_bucket is true)."
   type        = bool
   default     = true
 }
 
-variable "key_protect_key_crn" {
-  description = "CRN of the Key Protect Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true."
+variable "kms_key_crn" {
+  description = "CRN of the KMS Key to use to encrypt the data in the COS Bucket. Required if var.encryption_enabled and var.create_cos_bucket are true."
   type        = string
   default     = null
 }
@@ -295,6 +279,6 @@ variable "instance_cbr_rules" {
 
 variable "skip_iam_authorization_policy" {
   type        = bool
-  description = "Set to true to skip the creation of an IAM authorization policy that permits the COS instance created to read the encryption key from the Key Protect instance in `existing_key_protect_instance_guid`. WARNING: An authorization policy must exist before an encrypted bucket can be created"
+  description = "Set to true to skip the creation of an IAM authorization policy that permits the COS instance created to read the encryption key from the KMS instance in `existing_kms_instance_guid`. WARNING: An authorization policy must exist before an encrypted bucket can be created"
   default     = false
 }

--- a/version.tf
+++ b/version.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = ">= 1.51.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">=3.2.1"
-    }
   }
 }


### PR DESCRIPTION
### Description

Remove deprecated variables:

- service_endpoints
- bucket_endpoint

Rename variables:

- existing_key_protect_instance_guid > existing_kms_instance_guid
- key_protect_key_crn > kms_key_crn

Documentation updates to reflect that KMS keys, rather than specifically Key Protect keys can be used

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [x] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

If the following variables are used they should be removed from the module definition:

- service_endpoints
- bucket_endpoint

If the following variables are used on the module definition the key name should be updated and the value should remain the same.

- existing_key_protect_instance_guid > existing_kms_instance_guid
- key_protect_key_crn > kms_key_crn

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
