### PR TITLE
fix: disabled retention by default and added basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You need the following permissions to run this module.
 <!-- BEGIN EXAMPLES HOOK -->
 ## Examples
 
-- [ Basic Example (multiple COS Buckets without retention, encryption, tracking and monitoring enabled)](examples/basic)
+- [ Basic Example (multiple COS Buckets with retention, encryption, tracking and monitoring disabled)](examples/basic)
 - [ Complete Example (multiple COS Buckets with retention, encryption, tracking and monitoring enabled)](examples/complete)
 - [ COS Bucket without encryption using an existing COS instance and Key Protect instance + Keys](examples/existing-resources)
 - [ Financial Services Cloud Profile example](examples/fscloud)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You need the following permissions to run this module.
 <!-- BEGIN EXAMPLES HOOK -->
 ## Examples
 
+- [ Basic Example (multiple COS Buckets without retention, encryption, tracking and monitoring enabled)](examples/basic)
 - [ Complete Example (multiple COS Buckets with retention, encryption, tracking and monitoring enabled)](examples/complete)
 - [ COS Bucket without encryption using an existing COS instance and Key Protect instance + Keys](examples/existing-resources)
 - [ Financial Services Cloud Profile example](examples/fscloud)
@@ -147,7 +148,7 @@ You need the following permissions to run this module.
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where resources will be provisioned. | `string` | n/a | yes |
 | <a name="input_resource_key_existing_serviceid_crn"></a> [resource\_key\_existing\_serviceid\_crn](#input\_resource\_key\_existing\_serviceid\_crn) | CRN of existing serviceID to bind with resource key to be created. If null a new ServiceID is created for the resource key. | `string` | `null` | no |
 | <a name="input_retention_default"></a> [retention\_default](#input\_retention\_default) | Specifies default duration of time an object that can be kept unmodified for COS bucket. Only used if 'create\_cos\_bucket' is true. | `number` | `90` | no |
-| <a name="input_retention_enabled"></a> [retention\_enabled](#input\_retention\_enabled) | Retention enabled for COS bucket. Only used if 'create\_cos\_bucket' is true. | `bool` | `true` | no |
+| <a name="input_retention_enabled"></a> [retention\_enabled](#input\_retention\_enabled) | Retention enabled for COS bucket. Only used if 'create\_cos\_bucket' is true. | `bool` | `false` | no |
 | <a name="input_retention_maximum"></a> [retention\_maximum](#input\_retention\_maximum) | Specifies maximum duration of time an object that can be kept unmodified for COS bucket. Only used if 'create\_cos\_bucket' is true. | `number` | `350` | no |
 | <a name="input_retention_minimum"></a> [retention\_minimum](#input\_retention\_minimum) | Specifies minimum duration of time an object must be kept unmodified for COS bucket. Only used if 'create\_cos\_bucket' is true. | `number` | `90` | no |
 | <a name="input_retention_permanent"></a> [retention\_permanent](#input\_retention\_permanent) | Specifies a permanent retention status either enable or disable for COS bucket. Only used if 'create\_cos\_bucket' is true. | `bool` | `false` | no |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,7 @@
+# Basic Example (multiple COS Buckets without retention, encryption, tracking and monitoring enabled)
+
+An end-to-end example that will:
+- Create a new resource group (if existing one is not passed in).
+- Create a new Cloud Object Storage instance in the given resource group and region.
+- Create COS bucket-1
+- Create COS bucket-2 with cross region location

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,7 +1,6 @@
-# Basic Example (multiple COS Buckets without retention, encryption, tracking and monitoring enabled)
+# Basic Example (multiple COS Buckets with retention, encryption, tracking and monitoring disabled)
 
 An end-to-end example that will:
 - Create a new resource group (if existing one is not passed in).
 - Create a new Cloud Object Storage instance in the given resource group and region.
-- Create COS bucket-1
-- Create COS bucket-2 with cross region location
+- Create COS bucket-1 and bucket-2

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,36 @@
+##############################################################################
+# Resource Group
+##############################################################################
+
+module "resource_group" {
+  source = "git::https://github.com/terraform-ibm-modules/terraform-ibm-resource-group.git?ref=v1.0.5"
+  # if an existing resource group is not set (null) create a new one using prefix
+  resource_group_name          = var.resource_group == null ? "${var.prefix}-resource-group" : null
+  existing_resource_group_name = var.resource_group
+}
+
+
+module "cos_bucket1" {
+  source                              = "../../"
+  resource_group_id                   = module.resource_group.resource_group_id
+  region                              = var.region
+  cross_region_location               = null
+  cos_instance_name                   = "${var.prefix}-cos"
+  cos_tags                            = var.resource_tags
+  bucket_name                         = "${var.prefix}-bucket-1"
+  management_endpoint_type_for_bucket = var.management_endpoint_type_for_bucket
+  encryption_enabled                  = false
+}
+
+module "cos_bucket2" {
+  source                              = "../../"
+  resource_group_id                   = module.resource_group.resource_group_id
+  region                              = null
+  cross_region_location               = var.cross_region_location
+  bucket_name                         = "${var.prefix}-bucket-2"
+  management_endpoint_type_for_bucket = var.management_endpoint_type_for_bucket
+  archive_days                        = null
+  create_cos_instance                 = false
+  existing_cos_instance_id            = module.cos_bucket1.cos_instance_id
+  encryption_enabled                  = false
+}

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,0 +1,14 @@
+output "cos_instance_id" {
+  description = "COS instance id"
+  value       = module.cos_bucket1.cos_instance_id
+}
+
+output "bucket_name1" {
+  description = "Bucket Name"
+  value       = module.cos_bucket1.bucket_name
+}
+
+output "bucket_name2" {
+  description = "Bucket Name"
+  value       = module.cos_bucket2.bucket_name
+}

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -1,0 +1,5 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+}
+
+

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -1,5 +1,3 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
 }
-
-

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,0 +1,52 @@
+variable "ibmcloud_api_key" {
+  type        = string
+  description = "The IBM Cloud API Token"
+  sensitive   = true
+}
+
+variable "prefix" {
+  type        = string
+  default     = "test-cos"
+  description = "Prefix name for all related resources"
+}
+
+variable "resource_tags" {
+  type        = list(string)
+  description = "Optional list of tags to be added to created resources"
+  default     = []
+}
+
+# region needs to provide cross region support.
+variable "region" {
+  description = "Region where resources will be created"
+  type        = string
+  default     = "us-south"
+
+  validation {
+    condition     = can(regex("us-south|eu-de|jp-tok", var.region))
+    error_message = "Variable 'region' must be 'us-south' or 'eu-de', or 'jp-tok'. The encryption key must be created in a high availability key protect instance for cross region object storage"
+  }
+}
+
+variable "cross_region_location" {
+  description = "Specify the cross-regional bucket location. Supported values are 'us', 'eu', and 'ap'."
+  type        = string
+  default     = "us"
+
+  validation {
+    condition     = can(regex("us|eu|ap", var.cross_region_location))
+    error_message = "Variable 'cross_region_location' must be 'us' or 'eu', or 'ap'."
+  }
+}
+
+variable "management_endpoint_type_for_bucket" {
+  type        = string
+  description = "The type of endpoint for the IBM terraform provider to use to manage the bucket. (public, private, direct)"
+  default     = "public"
+}
+
+variable "resource_group" {
+  type        = string
+  description = "An existing resource group name to use for this example, if unset a new resource group will be created"
+  default     = null
+}

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,15 +6,5 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = "1.51.0"
     }
-    # The restapi provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
-    restapi = {
-      source  = "Mastercard/restapi"
-      version = ">= 1.18.0"
-    }
-    # The logdna provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
-    logdna = {
-      source  = "logdna/logdna"
-      version = ">= 1.14.2"
-    }
   }
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
+    ibm = {
+      source  = "ibm-cloud/ibm"
+      version = "1.51.0"
+    }
+    # The restapi provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
+    restapi = {
+      source  = "Mastercard/restapi"
+      version = ">= 1.18.0"
+    }
+    # The logdna provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
+    logdna = {
+      source  = "logdna/logdna"
+      version = ">= 1.14.2"
+    }
+  }
+}

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -93,6 +93,7 @@ module "cos_fscloud" {
   secondary_hpcs_key_crn                = var.secondary_hpcs_key_crn
   sysdig_crn                            = module.observability_instances.sysdig_crn
   activity_tracker_crn                  = local.at_crn
+  retention_enabled                     = false # retention disabled for test environments - enable for stage/prod
   bucket_cbr_rules = [
     {
       description      = "sample rule for bucket 1"

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -385,7 +385,7 @@
       "name": "retention_enabled",
       "type": "bool",
       "description": "Retention enabled for COS bucket. Only used if 'create_cos_bucket' is true.",
-      "default": true,
+      "default": false,
       "pos": {
         "filename": "variables.tf",
         "line": 132

--- a/profiles/fscloud/main.tf
+++ b/profiles/fscloud/main.tf
@@ -67,7 +67,7 @@ module "cos_primary_bucket" {
   create_cos_bucket          = var.create_cos_bucket
   bucket_name                = var.primary_bucket_name
   bucket_storage_class       = var.bucket_storage_class
-  retention_enabled          = false
+  retention_enabled          = var.retention_enabled
   archive_days               = var.archive_days
   archive_type               = var.archive_type
   expire_days                = null
@@ -89,7 +89,7 @@ module "cos_secondary_bucket" {
   create_cos_bucket          = var.create_cos_bucket
   bucket_name                = var.secondary_bucket_name
   bucket_storage_class       = var.bucket_storage_class
-  retention_enabled          = false
+  retention_enabled          = var.retention_enabled
   archive_days               = var.archive_days
   archive_type               = var.archive_type
   expire_days                = null

--- a/profiles/fscloud/variables.tf
+++ b/profiles/fscloud/variables.tf
@@ -120,6 +120,12 @@ variable "sysdig_crn" {
   default     = null
 }
 
+variable "retention_enabled" {
+  description = "Retention enabled for COS bucket. Only used if 'create_cos_bucket' is true."
+  type        = bool
+  default     = true
+}
+
 variable "archive_days" {
   description = "Specifies the number of days when the archive rule action takes effect. Only used if 'create_cos_bucket' is true."
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "management_endpoint_type_for_bucket" {
 variable "retention_enabled" {
   description = "Retention enabled for COS bucket. Only used if 'create_cos_bucket' is true."
   type        = bool
-  default     = true
+  default     = false # retention disabled for test environments - enable for stage/prod
 }
 
 variable "retention_default" {


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-cos/issues/366: set default retention policy to false, leave the retention enable only in the fscloud profile

https://github.com/terraform-ibm-modules/terraform-ibm-cos/issues/363 :  Create a simple basic example for the module without replication, encryption, etc.

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content
disabled retention policy by default
added basic example


---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
