### PR TITLE
fix: skip iam authorization policy based on kms instance rather than key

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-07T13:59:28Z",
+  "generated_at": "2023-05-10T14:37:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -65,7 +65,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.58.dss",
+  "version": "0.13.1+ibm.60.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You need the following permissions to run this module.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.51.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >=3.2.1 |
 
 ## Modules
 
@@ -114,6 +115,7 @@ You need the following permissions to run this module.
 | [ibm_iam_authorization_policy.policy](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/iam_authorization_policy) | resource |
 | [ibm_resource_instance.cos_instance](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/resource_instance) | resource |
 | [ibm_resource_key.resource_key](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/resource_key) | resource |
+| [null_resource.deprecation_notice](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 
@@ -135,7 +137,8 @@ You need the following permissions to run this module.
 | <a name="input_cross_region_location"></a> [cross\_region\_location](#input\_cross\_region\_location) | Specify the cross-regional bucket location. Supported values are 'us', 'eu', and 'ap'. If you pass a value for this, ensure to set the value of var.region to null. | `string` | `null` | no |
 | <a name="input_encryption_enabled"></a> [encryption\_enabled](#input\_encryption\_enabled) | Set as true to use KMS key encryption to encrypt data in COS bucket (only applicable when var.create\_cos\_bucket is true). | `bool` | `true` | no |
 | <a name="input_existing_cos_instance_id"></a> [existing\_cos\_instance\_id](#input\_existing\_cos\_instance\_id) | The ID of an existing cloud object storage instance. Required if 'var.create\_cos\_instance' is false. | `string` | `null` | no |
-| <a name="input_existing_kms_instance_guid"></a> [existing\_kms\_instance\_guid](#input\_existing\_kms\_instance\_guid) | The GUID of the Key Protect or Hyper Protect instance in which the key specified in var.kms\_key\_crn is coming from. Required if var.skip\_iam\_authorization\_policy is false in order to create an IAM Access Policy to allow Key protect or Hyper Protect to access the newly created COS instance. | `string` | `null` | no |
+| <a name="input_existing_kms_instance_guid"></a> [existing\_kms\_instance\_guid](#input\_existing\_kms\_instance\_guid) | WARNING: Deprecated KMS GUID, pass the full service instance id via existing\_kms\_instance\_id | `string` | `null` | no |
+| <a name="input_existing_kms_instance_id"></a> [existing\_kms\_instance\_id](#input\_existing\_kms\_instance\_id) | The KMS service instance id of the Key Protect or Hyper Protect instance in which the key specified in var.kms\_key\_crn is coming from. Required if var.skip\_iam\_authorization\_policy is false in order to create an IAM Access Policy to allow Key protect or Hyper Protect to access the newly created COS instance. | `string` | `null` | no |
 | <a name="input_expire_days"></a> [expire\_days](#input\_expire\_days) | Specifies the number of days when the expire rule action takes effect. Only used if 'create\_cos\_bucket' is true. | `number` | `365` | no |
 | <a name="input_hmac_key_name"></a> [hmac\_key\_name](#input\_hmac\_key\_name) | The name of the hmac key to be created. | `string` | `"hmac-cos-key"` | no |
 | <a name="input_hmac_key_role"></a> [hmac\_key\_role](#input\_hmac\_key\_role) | The role you want to be associated with your new hmac key. Valid roles are 'Writer', 'Reader', 'Manager', 'Content Reader', 'Object Reader', 'Object Writer'. | `string` | `"Manager"` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -67,7 +67,7 @@ locals {
 }
 
 module "key_protect_all_inclusive" {
-  source                    = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=v4.0.0"
+  source                    = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=v4.1.0"
   key_protect_instance_name = "${var.prefix}-kp"
   resource_group_id         = module.resource_group.resource_group_id
   enable_metrics            = false

--- a/examples/existing-resources/main.tf
+++ b/examples/existing-resources/main.tf
@@ -19,8 +19,7 @@ locals {
 }
 
 module "key_protect_all_inclusive" {
-  # DO NOT MERGE - pending new feature via PR into official version
-  source                    = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=expose-id"
+  source                    = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=v4.1.0"
   key_protect_instance_name = "${var.prefix}-kp"
   resource_group_id         = module.resource_group.resource_group_id
   enable_metrics            = false
@@ -54,8 +53,6 @@ module "cos_instance" {
   cross_region_location               = null
   activity_tracker_crn                = null
   resource_key_existing_serviceid_crn = ibm_iam_service_id.resource_key_existing_serviceid.crn
-  # DO NOT MERGE - just to drive logic in main module!
-  skip_iam_authorization_policy = false
 }
 
 # Create IAM Authorization Policy to allow COS to access key protect for the encryption key

--- a/examples/existing-resources/main.tf
+++ b/examples/existing-resources/main.tf
@@ -19,7 +19,8 @@ locals {
 }
 
 module "key_protect_all_inclusive" {
-  source                    = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=v4.0.0"
+  # DO NOT MERGE - pending new feature via PR into official version
+  source                    = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-all-inclusive.git?ref=expose-id"
   key_protect_instance_name = "${var.prefix}-kp"
   resource_group_id         = module.resource_group.resource_group_id
   enable_metrics            = false
@@ -48,12 +49,13 @@ module "cos_instance" {
   cos_instance_name                   = "${var.prefix}-cos"
   create_cos_bucket                   = false
   resource_group_id                   = module.resource_group.resource_group_id
-  existing_kms_instance_guid          = module.key_protect_all_inclusive.key_protect_guid
+  existing_kms_instance_id            = module.key_protect_all_inclusive.key_protect_id
   region                              = var.region
   cross_region_location               = null
   activity_tracker_crn                = null
   resource_key_existing_serviceid_crn = ibm_iam_service_id.resource_key_existing_serviceid.crn
-  skip_iam_authorization_policy       = true
+  # DO NOT MERGE - just to drive logic in main module!
+  skip_iam_authorization_policy = false
 }
 
 # Create IAM Authorization Policy to allow COS to access key protect for the encryption key

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   validate_cross_region_and_plan_input = var.cross_region_location != null && var.cos_plan == "cos-one-rate-plan" ? tobool("var.cos_plan is 'cos-one-rate-plan', then var.cross_region_location cannot be set as the one rate plan does not support cross region.") : true
   # tflint-ignore: terraform_unused_declarations
-  validate_kp_guid_input = var.encryption_enabled && var.create_cos_instance && var.skip_iam_authorization_policy == false && var.existing_kms_instance_guid == null ? tobool("A value must be passed for var.existing_kms_instance_guid when creating an instance, var.encryption_enabled is true and var.skip_iam_authorization_policy is false.") : true
+  validate_kp_id_input = var.encryption_enabled && var.create_cos_instance && var.skip_iam_authorization_policy == false && var.existing_kms_instance_id == null ? tobool("A value must be passed for var.existing_kms_instance_id when creating an instance, var.encryption_enabled is true and var.skip_iam_authorization_policy is false.") : true
   # tflint-ignore: terraform_unused_declarations
   validate_cross_region_location_inputs = var.create_cos_bucket && ((var.cross_region_location == null && var.region == null) || (var.cross_region_location != null && var.region != null)) ? tobool("If var.create_cos_bucket is true, then value needs to be provided for var.cross_region_location or var.region, but not both") : true
   # tflint-ignore: terraform_unused_declarations
@@ -59,12 +59,10 @@ locals {
   cos_instance_id          = var.create_cos_instance == true ? tolist(ibm_resource_instance.cos_instance[*].id)[0] : var.existing_cos_instance_id
   cos_instance_guid        = var.create_cos_instance == true ? tolist(ibm_resource_instance.cos_instance[*].guid)[0] : element(split(":", var.existing_cos_instance_id), length(split(":", var.existing_cos_instance_id)) - 3)
   create_access_policy_kms = var.encryption_enabled && var.create_cos_instance && !var.skip_iam_authorization_policy
-  kms_service = local.create_access_policy_kms && var.kms_key_crn != null ? (
-    can(regex(".*kms.*", var.kms_key_crn)) ? "kms" : (
-      can(regex(".*hs-crypto.*", var.kms_key_crn)) ? "hs-crypto" : null
-    )
-  ) : null
-
+  # "crn:v1:bluemix:public:hs-crypto:us-south:a/abac0df06b644a9cabc6e44f55b3880e:e6dce284-e80f-46e1-a3c1-830f7adff7a9::"
+  # "crn:v1:bluemix:public:kms:ca-tor:a/abac0df06b644a9cabc6e44f55b3880e:f2663809-20bd-40de-bcef-8fd6a9c1d247::"
+  # non capture group a-z and 0-9 followed by a colon, times 4, capture group a-z and - (the service)
+  kms_service = var.existing_kms_instance_id != null ? regex("(?:[a-z0-9]+:){4}([a-z-]+)", var.existing_kms_instance_id)[0] : null
 }
 
 # Create IAM Authorization Policy to allow COS to access KMS for the encryption key
@@ -73,7 +71,7 @@ resource "ibm_iam_authorization_policy" "policy" {
   source_service_name         = "cloud-object-storage"
   source_resource_instance_id = local.cos_instance_guid
   target_service_name         = local.kms_service
-  target_resource_instance_id = var.existing_kms_instance_guid
+  target_resource_instance_id = var.existing_kms_instance_id != null ? var.existing_kms_instance_id : var.existing_kms_instance_guid
   roles                       = ["Reader"]
 }
 
@@ -297,4 +295,14 @@ module "instance_cbr_rule" {
     tags = var.instance_cbr_rules[count.index].tags
   }]
   operations = var.instance_cbr_rules[count.index].operations == null ? [] : var.instance_cbr_rules[count.index].operations
+}
+
+resource "null_resource" "deprecation_notice" {
+  #  count = var.existing_kms_instance_guid != null ? 1 : 0
+  triggers = {
+    always_refresh = timestamp()
+  }
+  provisioner "local-exec" {
+    command = "echo 'WARNING: The existing_kms_instance_guid variable has been deprecated for this module and will be removed with the next major release. Please use existing_kms_instance_id to pass the full id of the instance'"
+  }
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -45,7 +45,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 240
+        "line": 246
       }
     },
     "bucket_name": {
@@ -205,7 +205,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 224
+        "line": 230
       }
     },
     "existing_cos_instance_id": {
@@ -220,13 +220,22 @@
     "existing_kms_instance_guid": {
       "name": "existing_kms_instance_guid",
       "type": "string",
-      "description": "The GUID of the Key Protect or Hyper Protect instance in which the key specified in var.kms_key_crn is coming from. Required if var.skip_iam_authorization_policy is false in order to create an IAM Access Policy to allow Key protect or Hyper Protect to access the newly created COS instance.",
+      "description": "WARNING: Deprecated KMS GUID, pass the full service instance id via existing_kms_instance_id",
+      "pos": {
+        "filename": "variables.tf",
+        "line": 218
+      }
+    },
+    "existing_kms_instance_id": {
+      "name": "existing_kms_instance_id",
+      "type": "string",
+      "description": "The KMS service instance id of the Key Protect or Hyper Protect instance in which the key specified in var.kms_key_crn is coming from. Required if var.skip_iam_authorization_policy is false in order to create an IAM Access Policy to allow Key protect or Hyper Protect to access the newly created COS instance.",
       "source": [
         "ibm_iam_authorization_policy.policy.target_resource_instance_id"
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 218
+        "line": 224
       },
       "immutable": true,
       "computed": true
@@ -285,7 +294,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 265
+        "line": 271
       }
     },
     "kms_key_crn": {
@@ -297,7 +306,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 230
+        "line": 236
       },
       "immutable": true
     },
@@ -428,7 +437,7 @@
       "default": false,
       "pos": {
         "filename": "variables.tf",
-        "line": 290
+        "line": 296
       }
     },
     "sysdig_crn": {
@@ -557,6 +566,12 @@
       "version_constraints": [
         "\u003e= 1.51.0"
       ]
+    },
+    "null": {
+      "source": "hashicorp/null",
+      "version_constraints": [
+        "\u003e=3.2.1"
+      ]
     }
   },
   "managed_resources": {
@@ -577,7 +592,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 87
+        "line": 85
       }
     },
     "ibm_cos_bucket.cos_bucket1": {
@@ -597,7 +612,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 163
+        "line": 161
       }
     },
     "ibm_iam_authorization_policy.policy": {
@@ -605,14 +620,14 @@
       "type": "ibm_iam_authorization_policy",
       "name": "policy",
       "attributes": {
-        "target_resource_instance_id": "existing_kms_instance_guid"
+        "target_resource_instance_id": "existing_kms_instance_id"
       },
       "provider": {
         "name": "ibm"
       },
       "pos": {
         "filename": "main.tf",
-        "line": 71
+        "line": 69
       }
     },
     "ibm_resource_instance.cos_instance": {
@@ -651,6 +666,18 @@
       "pos": {
         "filename": "main.tf",
         "line": 47
+      }
+    },
+    "null_resource.deprecation_notice": {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "deprecation_notice",
+      "provider": {
+        "name": "null"
+      },
+      "pos": {
+        "filename": "main.tf",
+        "line": 300
       }
     }
   },
@@ -730,7 +757,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 239
+        "line": 237
       }
     },
     "instance_cbr_rule": {
@@ -807,7 +834,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 273
+        "line": 271
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -216,7 +216,13 @@ variable "sysdig_crn" {
 ##############################################################################
 
 variable "existing_kms_instance_guid" {
-  description = "The GUID of the Key Protect or Hyper Protect instance in which the key specified in var.kms_key_crn is coming from. Required if var.skip_iam_authorization_policy is false in order to create an IAM Access Policy to allow Key protect or Hyper Protect to access the newly created COS instance."
+  description = "WARNING: Deprecated KMS GUID, pass the full service instance id via existing_kms_instance_id"
+  type        = string
+  default     = null
+}
+
+variable "existing_kms_instance_id" {
+  description = "The KMS service instance id of the Key Protect or Hyper Protect instance in which the key specified in var.kms_key_crn is coming from. Required if var.skip_iam_authorization_policy is false in order to create an IAM Access Policy to allow Key protect or Hyper Protect to access the newly created COS instance."
   type        = string
   default     = null
 }

--- a/version.tf
+++ b/version.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = ">= 1.51.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">=3.2.1"
+    }
   }
 }


### PR DESCRIPTION
### Description

ibm_iam_authorization_policy can only be created when a encrypted buckets are created, not when a instance with no buckets is created or when only unencrypted buckets are created.

This change introduces var.existing_kms_instance_id as module input, eventually replacing var.existing_kms_instance_guid. This id is the CRN which contains both the KMS instance type and region, neither of which are present in the id. This service is used to determine the kms service in the authorization policy, replacing the information previously extracted from the key crn.
Examples are updated to use an refreshed key protect all inclusive release that now outputs the id.

#352

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

`existing_kms_instance_id` is added as required property when creating an authorization policy.

Users providing `existing_kms_instance_guid` should update their code to provide the `existing_kms_instance_id` instead.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
