### PR TITLE
ci: auto mark modules as ready in catalog

### DIFF
--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -6,14 +6,13 @@ offerings:
     catalog_id: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd
     offering_id: 18cdd8f4-40c5-4fbf-9d62-1dd86a2deab3
     examples:
-      # TODO: Once support is added to the pipeline to handle code freeze windows, update mark_ready to true
       - name: basic
-        mark_ready: false
+        mark_ready: true
       - name: advanced
-        mark_ready: false
+        mark_ready: true
       - name: fscloud
-        mark_ready: false
+        mark_ready: true
       - name: one-rate-plan
-        mark_ready: false
+        mark_ready: true
       - name: replication
-        mark_ready: false
+        mark_ready: true


### PR DESCRIPTION
### Description

auto mark modules as ready in catalog now that pipeline supports not publishing during code freeze windows

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
