### PR TITLE
Bump IBM provider version to support CBR 1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.62.0, < 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1, < 4.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |
 

--- a/examples/advanced/version.tf
+++ b/examples/advanced/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1, < 2.0.0"
+      version = ">= 1.62.0, < 2.0.0"
     }
     logdna = {
       source  = "logdna/logdna"

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.56.1"
+      version = "1.62.0"
     }
   }
 }

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1, < 2.0.0"
+      version = ">= 1.62.0, < 2.0.0"
     }
     logdna = {
       source  = "logdna/logdna"

--- a/examples/one-rate-plan/version.tf
+++ b/examples/one-rate-plan/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.56.1"
+      version = "1.62.0"
     }
   }
 }

--- a/examples/replication/version.tf
+++ b/examples/replication/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.56.1"
+      version = "1.62.0"
     }
   }
 }

--- a/modules/buckets/README.md
+++ b/modules/buckets/README.md
@@ -62,7 +62,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.62.0, < 2.0.0 |
 
 ### Modules
 

--- a/modules/buckets/version.tf
+++ b/modules/buckets/version.tf
@@ -6,7 +6,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1, < 2.0.0"
+      version = ">= 1.62.0, < 2.0.0"
     }
   }
 }

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -89,7 +89,7 @@ module "cos_fscloud" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.62.0, <2.0.0 |
 
 ### Modules
 

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -7,7 +7,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1, <2.0.0"
+      version = ">= 1.62.0, <2.0.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1, < 2.0.0"
+      version = ">= 1.62.0, < 2.0.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
### Description

CBR module 1.20.0 requires IBM provider 1.62.0. This is used in the root module, meaning the minimum IBM provider is now 1.62.0

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

No release is required, this will allow future renovate upgrades to CBR 1.20.0. A patch release would allow the release notes to reflect a new minimum provider level if desired.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
