### PR TITLE
fix: validation to allow null values

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -156,7 +156,7 @@ variable "retention_default" {
   type        = number
   default     = 90
   validation {
-    condition     = var.retention_default > 0 && var.retention_default < 365243
+    condition     = var.retention_default == null ? true : (var.retention_default > 0 && var.retention_default < 365243)
     error_message = "The specified duration for retention maximum period is not a valid selection!"
   }
 }
@@ -166,7 +166,7 @@ variable "retention_maximum" {
   type        = number
   default     = 350
   validation {
-    condition     = var.retention_maximum > 0 && var.retention_maximum < 365243
+    condition     = (var.retention_maximum == null ? true : (var.retention_maximum > 0 && var.retention_maximum < 365243))
     error_message = "The specified duration for retention maximum period is not a valid selection!"
   }
 }
@@ -176,7 +176,7 @@ variable "retention_minimum" {
   type        = number
   default     = 90
   validation {
-    condition     = var.retention_minimum > 0 && var.retention_minimum < 365243
+    condition     = var.retention_minimum == null ? true : (var.retention_minimum > 0 && var.retention_minimum < 365243)
     error_message = "The specified duration for retention minimum period is not a valid selection!"
   }
 }


### PR DESCRIPTION
### Description

Relax validation on retention duration variables. When retention is not enabled, the values for each of the duration
variables could be null.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
