### PR TITLE
chore: Add bucket outputs

### DIFF
--- a/solutions/secure-regional-bucket/main.tf
+++ b/solutions/secure-regional-bucket/main.tf
@@ -106,3 +106,14 @@ module "cos" {
   existing_cos_instance_id = var.existing_cos_instance_id
   bucket_configs           = local.bucket_config
 }
+
+locals {
+  list_of_buckets = try(module.cos.buckets, [])
+  process_bucket_configs = flatten([for bucket in local.list_of_buckets : {
+    s3_endpoint_direct  = bucket.s3_endpoint_direct
+    s3_endpoint_private = bucket.s3_endpoint_private
+    s3_endpoint_public  = bucket.s3_endpoint_public
+    bucket_name         = bucket.bucket_name
+    }
+  ])
+}

--- a/solutions/secure-regional-bucket/main.tf
+++ b/solutions/secure-regional-bucket/main.tf
@@ -112,7 +112,6 @@ locals {
   process_bucket_configs = flatten([for bucket in local.list_of_buckets : {
     s3_endpoint_direct  = bucket.s3_endpoint_direct
     s3_endpoint_private = bucket.s3_endpoint_private
-    s3_endpoint_public  = bucket.s3_endpoint_public
     bucket_name         = bucket.bucket_name
     }
   ])

--- a/solutions/secure-regional-bucket/outputs.tf
+++ b/solutions/secure-regional-bucket/outputs.tf
@@ -5,3 +5,28 @@ output "buckets" {
   description = "List of buckets created"
   value       = module.cos.buckets
 }
+
+output "s3_endpoint_direct" {
+  description = "The s3 direct endpoint of the created bucket."
+  value       = try(local.process_bucket_configs[0].s3_endpoint_direct, "")
+}
+
+output "s3_endpoint_private" {
+  description = "The s3 private endpoint of the created bucket."
+  value       = try(local.process_bucket_configs[0].s3_endpoint_private, "")
+}
+
+output "s3_endpoint_public" {
+  description = "The s3 private public of the created bucket."
+  value       = try(local.process_bucket_configs[0].s3_endpoint_public, "")
+}
+
+output "bucket_name" {
+  description = "The name of the bucket that was created."
+  value       = try(local.process_bucket_configs[0].bucket_name, "")
+}
+
+output "cos_instance_crn" {
+  description = "The CRN of the COS instance containing the created bucket."
+  value       = var.existing_cos_instance_id
+}

--- a/solutions/secure-regional-bucket/outputs.tf
+++ b/solutions/secure-regional-bucket/outputs.tf
@@ -16,11 +16,6 @@ output "s3_endpoint_private" {
   value       = try(local.process_bucket_configs[0].s3_endpoint_private, "")
 }
 
-output "s3_endpoint_public" {
-  description = "The s3 private public of the created bucket."
-  value       = try(local.process_bucket_configs[0].s3_endpoint_public, "")
-}
-
 output "bucket_name" {
   description = "The name of the bucket that was created."
   value       = try(local.process_bucket_configs[0].bucket_name, "")


### PR DESCRIPTION
### Description
Require the outputs to be available to pass down into Project Stack inputs as there is no way to individually access the bucket config elements otherwise.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
