### PR TITLE
fix: add community catalog id in dependencies section of ibm_catalog.json

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -240,6 +240,7 @@
                             "flavors": [
                                 "instance"
                             ],
+                            "catalog_id": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3",
                             "id": "68921490-2778-4930-ac6d-bae7be6cd958-global",
                             "name": "deploy-arch-ibm-cos",
                             "version": ">= v8.1.4"
@@ -303,6 +304,7 @@
                             "flavors": [
                                 "instance"
                             ],
+                            "catalog_id": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3",
                             "id": "68921490-2778-4930-ac6d-bae7be6cd958-global",
                             "name": "deploy-arch-ibm-cos",
                             "version": ">= v8.1.4"


### PR DESCRIPTION
### Description

In https://github.com/terraform-ibm-modules/terraform-ibm-cos/pull/654 we removed the catalog ID, as it was pointing to a private catalog. However since the dependency DA is actually in community (and not main catalog), we need to add the catalog ID of the community registry

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
