### PR TITLE
Revert "Update ibm_catalog.json - remove dependencies section"

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -235,6 +235,17 @@
                     "name": "secure-cross-regional-bucket",
                     "working_directory": "solutions/secure-cross-regional-bucket",
                     "install_type": "extension",
+                    "dependencies": [
+                        {
+                            "flavors": [
+                                "instance"
+                            ],
+                            "catalog_id": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3",
+                            "id": "68921490-2778-4930-ac6d-bae7be6cd958-global",
+                            "name": "deploy-arch-ibm-cos",
+                            "version": ">= v8.1.4"
+                        }
+                    ],
                     "compliance": {
                         "authority": "scc-v3",
                         "profiles": [
@@ -288,6 +299,17 @@
                     "name": "secure-regional-bucket",
                     "working_directory": "solutions/secure-regional-bucket",
                     "install_type": "extension",
+                    "dependencies": [
+                        {
+                            "flavors": [
+                                "instance"
+                            ],
+                            "catalog_id": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3",
+                            "id": "68921490-2778-4930-ac6d-bae7be6cd958-global",
+                            "name": "deploy-arch-ibm-cos",
+                            "version": ">= v8.1.4"
+                        }
+                    ],
                     "compliance": {
                         "authority": "scc-v3",
                         "profiles": [


### PR DESCRIPTION
Reverts terraform-ibm-modules/terraform-ibm-cos#663

so it seems I can’t mark a version as ready if its an extension type with adding a dependencies section:
![image](https://github.com/terraform-ibm-modules/terraform-ibm-scc-da/assets/29608224/60bf3cb9-0925-4727-987d-631e39e039d5)