### PR TITLE
fix: clean up variable descriptions

### DIFF
--- a/solutions/secure-cross-regional-bucket/variables.tf
+++ b/solutions/secure-cross-regional-bucket/variables.tf
@@ -75,7 +75,7 @@ variable "management_endpoint_type_for_bucket" {
 }
 
 variable "cross_region_location" {
-  description = "Specify the cross-region bucket location. Possible values: `us`, `eu`, `ap`. If specified, set the value of `region` and `single_site_location` to `null`."
+  description = "Specify the cross-region bucket location. Possible values: `us`, `eu`, `ap`."
   type        = string
 }
 

--- a/solutions/secure-regional-bucket/main.tf
+++ b/solutions/secure-regional-bucket/main.tf
@@ -62,7 +62,7 @@ locals {
 # KMS Key
 #######################################################################################################################
 
-# KMS root key for COS cross region bucket
+# KMS root key for COS bucket
 module "kms" {
   providers = {
     ibm = ibm.kms


### PR DESCRIPTION
### Description

Update description of cross regional location in DA.

❗ The default value for the `regional` kms key and key ring names is `cross-region-`. Should this be address in this issue, or should it be avoided to avoid impacting existing deployments that already exist?

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
