### PR TITLE
fix: added secrets manager crn validation when var.skip_cos_sm_auth_policy is false

### DIFF
--- a/solutions/instance/catalogValidationValues.json.template
+++ b/solutions/instance/catalogValidationValues.json.template
@@ -1,7 +1,5 @@
 {
   "ibmcloud_api_key": $VALIDATION_APIKEY,
   "resource_group_name": $PREFIX,
-  "cos_instance_name": $PREFIX,
-  "skip_cos_sm_auth_policy": true
-
+  "cos_instance_name": $PREFIX
 }

--- a/solutions/instance/catalogValidationValues.json.template
+++ b/solutions/instance/catalogValidationValues.json.template
@@ -2,5 +2,6 @@
   "ibmcloud_api_key": $VALIDATION_APIKEY,
   "resource_group_name": $PREFIX,
   "cos_instance_name": $PREFIX,
-  "existing_secrets_manager_instance_crn": $SM_CRN
+  "skip_cos_sm_auth_policy": true
+
 }

--- a/solutions/instance/catalogValidationValues.json.template
+++ b/solutions/instance/catalogValidationValues.json.template
@@ -1,5 +1,6 @@
 {
   "ibmcloud_api_key": $VALIDATION_APIKEY,
   "resource_group_name": $PREFIX,
-  "cos_instance_name": $PREFIX
+  "cos_instance_name": $PREFIX,
+  "existing_secrets_manager_instance_crn": $SM_CRN
 }

--- a/solutions/instance/main.tf
+++ b/solutions/instance/main.tf
@@ -62,6 +62,8 @@ locals {
 
   # tflint-ignore: terraform_unused_declarations
   validate_sm_crn = length(local.service_credential_secrets) > 0 && var.existing_secrets_manager_instance_crn == null ? tobool("`existing_secrets_manager_instance_crn` is required when adding service credentials to a secrets manager secret.") : false
+  # tflint-ignore: terraform_unused_declarations
+  validate_sm_crn2 = var.skip_cos_sm_auth_policy == false && var.existing_secrets_manager_instance_crn == null ? tobool("`existing_secrets_manager_instance_crn` is required when `skip_cos_sm_auth_policy` is false") : false
 }
 
 module "secrets_manager_service_credentials" {

--- a/solutions/instance/main.tf
+++ b/solutions/instance/main.tf
@@ -17,7 +17,7 @@ module "cos" {
 }
 
 resource "ibm_iam_authorization_policy" "secrets_manager_key_manager" {
-  count                       = var.skip_cos_sm_auth_policy ? 0 : 1
+  count                       = var.skip_cos_sm_auth_policy || var.existing_secrets_manager_instance_crn == null ? 0 : 1
   depends_on                  = [module.cos]
   source_service_name         = "secrets-manager"
   source_resource_instance_id = local.existing_secrets_manager_instance_guid
@@ -62,8 +62,6 @@ locals {
 
   # tflint-ignore: terraform_unused_declarations
   validate_sm_crn = length(local.service_credential_secrets) > 0 && var.existing_secrets_manager_instance_crn == null ? tobool("`existing_secrets_manager_instance_crn` is required when adding service credentials to a secrets manager secret.") : false
-  # tflint-ignore: terraform_unused_declarations
-  validate_sm_crn2 = var.skip_cos_sm_auth_policy == false && var.existing_secrets_manager_instance_crn == null ? tobool("`existing_secrets_manager_instance_crn` is required when `skip_cos_sm_auth_policy` is false") : false
 }
 
 module "secrets_manager_service_credentials" {


### PR DESCRIPTION
### Description

PR: https://github.com/terraform-ibm-modules/terraform-ibm-cos/issues/708

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Added validation for `var.existing_secrets_manager_instance_crn` when `var.skip_cos_sm_auth_policy` is false
- Added "skip_cos_sm_auth_policy": true in `solutions/instance/catalogValidationValues.json.template` as we are not creating sm credentials while catalog validation

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
