### PR TITLE
feat:exposed visibility value for the provider in the DA

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -6,6 +6,7 @@ CRA_TARGETS:
     PROFILE_ID: "bfacb71d-4b84-41ac-9825-e8a3a3eb7405" # SCC profile ID (currently set to IBM Cloud Framework for Financial Services 1.6.0 profile).
     CRA_ENVIRONMENT_VARIABLES:  # An optional map of environment variables for CRA, where the key is the variable name and value is the value. Useful for providing TF_VARs.
       TF_VAR_resource_group_name: "terraform-ibm-cos"
+      TF_VAR_provider_visibility: "public"
   - CRA_TARGET: "solutions/secure-cross-regional-bucket"  # Target directory for CRA scan. If not provided, the CRA Scan will not be run.
     CRA_IGNORE_RULES_FILE: "cra-tf-validate-ignore-rules.json" # CRA Ignore file to use. If not provided, it checks the repo root directory for `cra-tf-validate-ignore-rules.json`
     PROFILE_ID: "bfacb71d-4b84-41ac-9825-e8a3a3eb7405" # SCC profile ID (currently set to IBM Cloud Framework for Financial Services 1.6.0 profile).
@@ -14,6 +15,7 @@ CRA_TARGETS:
       TF_VAR_existing_cos_instance_id: "crn:v1:bluemix:public:cloud-object-storage:global:a/abac0df06b644a9cabc6e44f55b3880e:12345a67-12ab-1a23-abc1-1a2345abcde6::"
       TF_VAR_bucket_name: "mock"
       TF_VAR_cross_region_location: us
+      TF_VAR_provider_visibility: "public"
   - CRA_TARGET: "solutions/secure-regional-bucket"  # Target directory for CRA scan. If not provided, the CRA Scan will not be run.
     CRA_IGNORE_RULES_FILE: "cra-tf-validate-ignore-rules.json" # CRA Ignore file to use. If not provided, it checks the repo root directory for `cra-tf-validate-ignore-rules.json`
     PROFILE_ID: "bfacb71d-4b84-41ac-9825-e8a3a3eb7405" # SCC profile ID (currently set to IBM Cloud Framework for Financial Services 1.6.0 profile).
@@ -21,3 +23,4 @@ CRA_TARGETS:
       TF_VAR_existing_kms_instance_crn: "crn:v1:bluemix:public:hs-crypto:us-south:a/abac0df06b644a9cabc6e44f55b3880e:e6dce284-e80f-46e1-a3c1-830f7adff7a9::"
       TF_VAR_existing_cos_instance_id: "crn:v1:bluemix:public:cloud-object-storage:global:a/abac0df06b644a9cabc6e44f55b3880e:12345a67-12ab-1a23-abc1-1a2345abcde6::"
       TF_VAR_bucket_name: "mock"
+      TF_VAR_provider_visibility: "public"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -230,7 +230,27 @@
                                 "description": "This architecture supports creating and configuring an IBM Cloud Object Storage instance."
                             }
                         ]
-                    }
+                    },
+                    "configuration":[
+                        {
+                        "key": "provider_visibility",
+                        "options": [
+                          {
+                            "displayname": "private",
+                            "value": "private"
+                          },
+                          {
+                            "displayname": "public",
+                            "value": "public"
+                          },
+                          {
+                            "displayname": "public-and-private",
+                            "value": "public-and-private"
+                          }
+                        ]
+                      }
+                    ]
+
                 },
                 {
                     "label": "Secure cross-region bucket",
@@ -295,7 +315,27 @@
                                 "description": "This architecture supports creating and configuring a secure cross-region bucket."
                             }
                         ]
-                    }
+                    },
+                    "configuration":[
+                        {
+                        "key": "provider_visibility",
+                        "options": [
+                          {
+                            "displayname": "private",
+                            "value": "private"
+                          },
+                          {
+                            "displayname": "public",
+                            "value": "public"
+                          },
+                          {
+                            "displayname": "public-and-private",
+                            "value": "public-and-private"
+                          }
+                        ]
+                      }
+                    ]
+
                 },
                 {
                     "label": "Secure regional bucket",
@@ -364,7 +404,26 @@
                                 "description": "This architecture supports creating and configuring a regional bucket."
                             }
                         ]
-                    }
+                    },
+                    "configuration":[
+                        {
+                        "key": "provider_visibility",
+                        "options": [
+                          {
+                            "displayname": "private",
+                            "value": "private"
+                          },
+                          {
+                            "displayname": "public",
+                            "value": "public"
+                          },
+                          {
+                            "displayname": "public-and-private",
+                            "value": "public-and-private"
+                          }
+                        ]
+                      }
+                    ]
                 }
             ]
         }

--- a/solutions/instance/provider.tf
+++ b/solutions/instance/provider.tf
@@ -1,4 +1,5 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   ibmcloud_timeout = 60
+  visibility       = var.provider_visibility
 }

--- a/solutions/instance/variables.tf
+++ b/solutions/instance/variables.tf
@@ -113,3 +113,13 @@ variable "skip_cos_sm_auth_policy" {
   default     = false
   description = "Whether an IAM authorization policy is created for Secrets Manager instance to create a service credential secrets for Cloud Object Storage. Set to `true` to use an existing policy."
 }
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}

--- a/solutions/secure-cross-regional-bucket/provider.tf
+++ b/solutions/secure-cross-regional-bucket/provider.tf
@@ -1,10 +1,12 @@
 provider "ibm" {
   alias            = "cos"
   ibmcloud_api_key = var.ibmcloud_api_key
+  visibility       = var.provider_visibility
 }
 
 provider "ibm" {
   alias            = "kms"
   ibmcloud_api_key = var.ibmcloud_kms_api_key != null ? var.ibmcloud_kms_api_key : var.ibmcloud_api_key
   region           = local.existing_kms_instance_region
+  visibility       = var.provider_visibility
 }

--- a/solutions/secure-cross-regional-bucket/variables.tf
+++ b/solutions/secure-cross-regional-bucket/variables.tf
@@ -175,3 +175,13 @@ variable "object_lock_duration_years" {
   type        = number
   default     = 0
 }
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}

--- a/solutions/secure-regional-bucket/provider.tf
+++ b/solutions/secure-regional-bucket/provider.tf
@@ -1,10 +1,12 @@
 provider "ibm" {
   alias            = "cos"
   ibmcloud_api_key = var.ibmcloud_api_key
+  visibility       = var.provider_visibility
 }
 
 provider "ibm" {
   alias            = "kms"
   ibmcloud_api_key = var.ibmcloud_kms_api_key != null ? var.ibmcloud_kms_api_key : var.ibmcloud_api_key
   region           = local.existing_kms_instance_region
+  visibility       = var.provider_visibility
 }

--- a/solutions/secure-regional-bucket/variables.tf
+++ b/solutions/secure-regional-bucket/variables.tf
@@ -188,3 +188,13 @@ variable "object_lock_duration_years" {
   type        = number
   default     = 0
 }
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -273,6 +273,7 @@ func TestRunSolutions(t *testing.T) {
 		"resource_group_name":                    fmt.Sprintf("%s-resource-group", prefix),
 		"existing_secrets_manager_instance_crn":  permanentResources["secretsManagerCRN"],
 		"existing_secrets_manager_endpoint_type": "public",
+		"provider_visibility":                    "public",
 		"service_credential_secrets": []map[string]interface{}{
 			{
 				"secret_group_name": fmt.Sprintf("%s-secret-group", prefix),
@@ -306,6 +307,7 @@ func TestRunSolutions(t *testing.T) {
 				"region":                              region,
 				"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 				"kms_endpoint_type":                   "public",
+				"provider_visibility":                 "public",
 				"management_endpoint_type_for_bucket": "public",
 				"existing_cos_instance_id":            instanceOptions.LastTestTerraformOutputs["cos_instance_id"],
 			},
@@ -326,6 +328,7 @@ func TestRunSolutions(t *testing.T) {
 				"existing_kms_key_crn":                permanentResources["hpcs_south_root_key_crn"],
 				"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 				"management_endpoint_type_for_bucket": "public",
+				"provider_visibility":                 "public",
 				"existing_cos_instance_id":            instanceOptions.LastTestTerraformOutputs["cos_instance_id"],
 			},
 		})


### PR DESCRIPTION
### Description

exposed [visibility](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#visibility) value for the provider in the DA , with default value set to "private"

[Git issue](https://github.ibm.com/GoldenEye/issues/issues/11321)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

exposes visibility value for the provider in the DA

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
