### PR TITLE
fix:added CBR doc link in variable description

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -250,7 +250,7 @@
                         ]
                       },
                       {
-                        "key":"cbr_rules"
+                        "key":"instance_cbr_rules"
                       }
                     ]
 
@@ -338,7 +338,7 @@
                         ]
                       },
                       {
-                        "key":"cbr_rules"
+                        "key":"instance_cbr_rules"
                       }
                     ]
 
@@ -430,7 +430,7 @@
                         ]
                       },
                       {
-                        "key":"cbr_rules"
+                        "key":"instance_cbr_rules"
                       }
                     ]
                 }

--- a/solutions/instance/variables.tf
+++ b/solutions/instance/variables.tf
@@ -147,7 +147,7 @@ variable "instance_cbr_rules" {
       }))
     })))
   }))
-  description = "The list of context-based restriction rules to create for the instance."
+  description = "The list of context-based restriction rules to create for the instance.[Learn more](https://github.com/terraform-ibm-modules/terraform-ibm-cos/blob/main/solutions/instance/DA-cbr_rules.md)"
   default     = []
   # Validation happens in the rule module
 }

--- a/solutions/secure-cross-regional-bucket/variables.tf
+++ b/solutions/secure-cross-regional-bucket/variables.tf
@@ -208,7 +208,7 @@ variable "instance_cbr_rules" {
       }))
     })))
   }))
-  description = "The list of context-based restriction rules to create for the instance."
+  description = "The list of context-based restriction rules to create for the instance.[Learn more](https://github.com/terraform-ibm-modules/terraform-ibm-cos/blob/main/solutions/secure-cross-regional-bucket/DA-cbr_rules.md)"
   default     = []
   # Validation happens in the rule module
 }

--- a/solutions/secure-regional-bucket/variables.tf
+++ b/solutions/secure-regional-bucket/variables.tf
@@ -221,7 +221,7 @@ variable "instance_cbr_rules" {
       }))
     })))
   }))
-  description = "The list of context-based restriction rules to create for the instance."
+  description = "The list of context-based restriction rules to create for the instance. [Learn more](https://github.com/terraform-ibm-modules/terraform-ibm-cos/blob/main/solutions/secure-regional-bucket/DA-cbr_rules.md)"
   default     = []
   # Validation happens in the rule module
 }


### PR DESCRIPTION
### Description

added CBR doc link in variable description and fixed variable name in ibm_catalog.json

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

adds CBR doc link in variable description and fixes variable name in ibm_catalog.json

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
