### PR TITLE
fix: exposed `management_endpoint_type_for_bucket` in catalog

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -759,6 +759,19 @@
               "key": "bucket_hard_quota"
             },
             {
+              "key": "management_endpoint_type_for_bucket",
+              "options": [
+                {
+                  "displayname": "direct",
+                  "value": "direct"
+                },
+                {
+                  "displayname": "private",
+                  "value": "private"
+                }
+              ]
+            },
+            {
               "key": "monitoring_crn"
             },
             {
@@ -1541,6 +1554,19 @@
             },
             {
               "key": "bucket_hard_quota"
+            },
+            {
+              "key": "management_endpoint_type_for_bucket",
+              "options": [
+                {
+                  "displayname": "direct",
+                  "value": "direct"
+                },
+                {
+                  "displayname": "private",
+                  "value": "private"
+                }
+              ]
             },
             {
               "key": "monitoring_crn"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -421,7 +421,6 @@
             },
             {
               "key": "management_endpoint_type_for_bucket",
-              "hidden": true,
               "options": [
                 {
                   "displayname": "direct",
@@ -1147,7 +1146,6 @@
             },
             {
               "key": "management_endpoint_type_for_bucket",
-              "hidden": true,
               "options": [
                 {
                   "displayname": "direct",

--- a/solutions/cross-regional-bucket/fully-configurable/variables.tf
+++ b/solutions/cross-regional-bucket/fully-configurable/variables.tf
@@ -126,7 +126,7 @@ variable "bucket_name" {
 variable "management_endpoint_type_for_bucket" {
   description = "The type of endpoint for the IBM terraform provider to manage the bucket. Possible values: `public`, `private`, `direct`."
   type        = string
-  default     = "private"
+  default     = "direct"
   validation {
     condition     = contains(["public", "private", "direct"], var.management_endpoint_type_for_bucket)
     error_message = "The value of management_endpoint_type_for_bucket must be one of: `public`, `private`, `direct`."

--- a/solutions/cross-regional-bucket/security-enforced/main.tf
+++ b/solutions/cross-regional-bucket/security-enforced/main.tf
@@ -14,7 +14,7 @@ module "cross_regional_bucket" {
   existing_cos_instance_crn           = var.existing_cos_instance_crn
   bucket_access_tags                  = var.bucket_access_tags
   bucket_name                         = var.bucket_name
-  management_endpoint_type_for_bucket = "private"
+  management_endpoint_type_for_bucket = var.management_endpoint_type_for_bucket
   cross_region_location               = var.cross_region_location
   bucket_storage_class                = var.bucket_storage_class
   force_delete                        = var.force_delete

--- a/solutions/cross-regional-bucket/security-enforced/variables.tf
+++ b/solutions/cross-regional-bucket/security-enforced/variables.tf
@@ -96,6 +96,16 @@ variable "bucket_name" {
   description = "The name to give the newly provisioned Object Storage bucket."
 }
 
+variable "management_endpoint_type_for_bucket" {
+  description = "The type of endpoint for the IBM terraform provider to manage the bucket. Possible values:  `private`, `direct`."
+  type        = string
+  default     = "direct"
+  validation {
+    condition     = contains(["private", "direct"], var.management_endpoint_type_for_bucket)
+    error_message = "The value of management_endpoint_type_for_bucket must be one of: `private`, `direct`."
+  }
+}
+
 variable "cross_region_location" {
   description = "Specify the cross-region bucket location. Possible values: `us`, `eu`, `ap`."
   type        = string

--- a/solutions/regional-bucket/fully-configurable/variables.tf
+++ b/solutions/regional-bucket/fully-configurable/variables.tf
@@ -135,7 +135,7 @@ variable "bucket_name" {
 variable "management_endpoint_type_for_bucket" {
   description = "The type of endpoint for the IBM terraform provider to manage the bucket. Possible values: `public`, `private`, `direct`."
   type        = string
-  default     = "private"
+  default     = "direct"
   validation {
     condition     = contains(["public", "private", "direct"], var.management_endpoint_type_for_bucket)
     error_message = "The value of management_endpoint_type_for_bucket must be one of: `public`, `private`, `direct`."

--- a/solutions/regional-bucket/security-enforced/main.tf
+++ b/solutions/regional-bucket/security-enforced/main.tf
@@ -14,7 +14,7 @@ module "regional_bucket" {
   existing_cos_instance_crn           = var.existing_cos_instance_crn
   bucket_access_tags                  = var.bucket_access_tags
   bucket_name                         = var.bucket_name
-  management_endpoint_type_for_bucket = "private"
+  management_endpoint_type_for_bucket = var.management_endpoint_type_for_bucket
   region                              = var.region
   bucket_storage_class                = var.bucket_storage_class
   force_delete                        = var.force_delete

--- a/solutions/regional-bucket/security-enforced/variables.tf
+++ b/solutions/regional-bucket/security-enforced/variables.tf
@@ -105,6 +105,16 @@ variable "bucket_name" {
   description = "The name to give the newly provisioned Object Storage bucket."
 }
 
+variable "management_endpoint_type_for_bucket" {
+  description = "The type of endpoint for the IBM terraform provider to manage the bucket. Possible values:  `private`, `direct`."
+  type        = string
+  default     = "direct"
+  validation {
+    condition     = contains(["private", "direct"], var.management_endpoint_type_for_bucket)
+    error_message = "The value of management_endpoint_type_for_bucket must be one of: `private`, `direct`."
+  }
+}
+
 variable "bucket_storage_class" {
   type        = string
   description = "The storage class of the newly provisioned Object Storage bucket. Possible values: `standard`, `vault`, `cold`, `smart` `onerate_active`."


### PR DESCRIPTION
### Description

https://github.ibm.com/GoldenEye/issues/issues/15305

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Exposes `management_endpoint_type_for_bucket` in catalog.json and changes default to `direct`

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
